### PR TITLE
feat: agent tool render split + document titlebar + drag-context-menu…

### DIFF
--- a/app/flowix-desktop/src/commands/thread.rs
+++ b/app/flowix-desktop/src/commands/thread.rs
@@ -8,7 +8,7 @@ use tauri::State;
 use tokio::process::Command;
 
 use crate::agent::default_agent_id;
-use crate::threads::{ChatMessage, ThreadInfo};
+use crate::threads::{ChatMessage, ThreadInfo, ThreadMessagesPage};
 
 use super::AppState;
 
@@ -52,6 +52,33 @@ pub async fn thread_get(
         }),
         None => Err("Thread not found".to_string()),
     }
+}
+
+/// Layer 4: 分页加载 thread 历史. 取代 thread_get 在 1MB 级 thread 上的全量
+/// 序列化开销, IPC payload 从 ~1MB 降到 ~100KB (100 条 × 平均 1KB).
+///
+/// 参数:
+///   - thread_id: 目标 thread
+///   - before_sequence: None → 取最近 limit 条; Some(s) → 取 sequence < s 的最近 limit 条
+///   - limit: 单次返回上限, 服务端 clamp 到 [1, 1000], 默认建议前端传 100
+///
+/// 返回 ThreadMessagesPage { messages (ASC), oldest_sequence, has_more }
+/// 前端用 oldest_sequence 作为下一页 cursor, has_more 决定顶部 prefetch.
+///
+/// 旧 thread_get 保留不删 ── 一些路径 (调试 / 全量导出) 仍可能需要,
+/// 也避免破坏未迁移到分页的调用方.
+#[tauri::command]
+pub async fn thread_get_page(
+    thread_id: String,
+    before_sequence: Option<i64>,
+    limit: i64,
+    state: State<'_, AppState>,
+) -> Result<ThreadMessagesPage, String> {
+    let manager = state.thread_manager.read().await;
+    manager
+        .get_thread_messages_page(&thread_id, before_sequence, limit)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/app/flowix-desktop/src/lib.rs
+++ b/app/flowix-desktop/src/lib.rs
@@ -733,6 +733,7 @@ pub fn run() {
             commands::thread::thread_list,
             commands::thread::thread_create,
             commands::thread::thread_get,
+            commands::thread::thread_get_page,
             commands::thread::codex_thread_list,
             commands::thread::codex_thread_get,
             commands::thread::codex_thread_session_id,

--- a/app/flowix-desktop/src/threads.rs
+++ b/app/flowix-desktop/src/threads.rs
@@ -60,6 +60,18 @@ pub struct Thread {
     pub messages: Vec<ChatMessage>,
 }
 
+/// Layer 4: 分页加载的返回类型. 前端用 `oldest_sequence` 作下一页 cursor,
+/// `has_more` 决定是否在顶部显示"加载更多"或自动 prefetch.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreadMessagesPage {
+    pub messages: Vec<ChatMessage>,
+    /// 本批最早一条消息的 sequence; None 表示本批为空 (thread 无消息或 before_sequence 已到顶).
+    pub oldest_sequence: Option<i64>,
+    /// 是否还有更早的历史. false 时前端停止 prefetch 顶部.
+    pub has_more: bool,
+}
+
 pub struct ThreadManager {
     conn: Mutex<Connection>,
 }
@@ -251,6 +263,84 @@ impl ThreadManager {
         let messages = rows.collect::<Result<Vec<_>, _>>()?;
 
         Ok(Some(Thread { info, messages }))
+    }
+
+    /// Layer 4: 分页加载 thread 历史 ── 不再一次 SELECT 全部, 按 sequence DESC
+    /// 取最近 `limit` 条, 在 Rust 侧 reverse 回 ASC 返回. `before_sequence`:
+    ///   - None: 取最近 `limit` 条 (首次进入 thread)
+    ///   - Some(s): 取 sequence < s 的最近 `limit` 条 (用户向上滚加载更早)
+    ///
+    /// 返回 `(messages, oldest_sequence, has_more)`:
+    ///   - oldest_sequence: 本批最早一条的 sequence (或 None 若本批为空), 用作下一页 cursor
+    ///   - has_more: 是否还有更早的历史 (用本批 oldest 之前还有几条判断)
+    ///
+    /// 不返回 ThreadInfo (那部分仍走 get_thread 全量 ── 但实际上 ThreadInfo
+    /// 在 thread_list 缓存里, 前端 loadThread 走 list 取 title 即可不必再查).
+    /// 这里专心做 messages 分页, 单一职责.
+    pub async fn get_thread_messages_page(
+        &self,
+        thread_id: &str,
+        before_sequence: Option<i64>,
+        limit: i64,
+    ) -> Result<ThreadMessagesPage, ThreadError> {
+        // 上下文限制: limit 卡在 [1, 1000] 防御性兜底, 避免前端误传 0 或巨大值.
+        let limit = limit.clamp(1, 1000);
+        let conn = self.lock_conn();
+
+        // DESC + LIMIT 取最近 N 条 ── (thread_id, sequence) 复合索引覆盖,
+        // 单次查询即可定位, 无需 OFFSET 扫描.
+        let messages: Vec<(ChatMessage, i64)> = match before_sequence {
+            Some(before) => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, role, content, llm_content, system_reminder_directory, timestamp,
+                            is_loading, tool_call_id, tool_name, tool_data, tool_input, tool_calls, reasoning,
+                            is_completed, is_collapsed, sequence
+                     FROM thread_messages
+                     WHERE thread_id = ?1 AND sequence < ?2
+                     ORDER BY sequence DESC LIMIT ?3",
+                )?;
+                let rows =
+                    stmt.query_map(params![thread_id, before, limit], Self::row_to_message_with_seq)?;
+                rows.collect::<Result<Vec<_>, _>>()?
+            }
+            None => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, role, content, llm_content, system_reminder_directory, timestamp,
+                            is_loading, tool_call_id, tool_name, tool_data, tool_input, tool_calls, reasoning,
+                            is_completed, is_collapsed, sequence
+                     FROM thread_messages
+                     WHERE thread_id = ?1
+                     ORDER BY sequence DESC LIMIT ?2",
+                )?;
+                let rows =
+                    stmt.query_map(params![thread_id, limit], Self::row_to_message_with_seq)?;
+                rows.collect::<Result<Vec<_>, _>>()?
+            }
+        };
+
+        // 反转为 ASC 给前端 (前端 messages 按时间顺序排列).
+        let oldest_sequence = messages.last().map(|(_, seq)| *seq); // DESC 排序时最后一个是最小 sequence
+        let mut messages_asc: Vec<ChatMessage> = messages.into_iter().map(|(m, _)| m).collect();
+        messages_asc.reverse();
+
+        // has_more: 看 oldest_sequence 之前还有没有数据. 单 COUNT(*) 极快
+        // (复合索引覆盖, 不读 row body).
+        let has_more = if let Some(oldest) = oldest_sequence {
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM thread_messages WHERE thread_id = ?1 AND sequence < ?2",
+                params![thread_id, oldest],
+                |row| row.get(0),
+            )?;
+            count > 0
+        } else {
+            false
+        };
+
+        Ok(ThreadMessagesPage {
+            messages: messages_asc,
+            oldest_sequence,
+            has_more,
+        })
     }
 
     pub async fn add_message(
@@ -506,6 +596,17 @@ impl ThreadManager {
             is_collapsed: int_to_opt_bool(row.get(14)?),
         })
     }
+
+    /// Layer 4: 与 `row_to_message` 同形, 但 SELECT 多取了 sequence 列
+    /// (column 15). 分页 SQL 用这个版本拿回 sequence 以构造 oldest_sequence
+    /// cursor; 其它路径用 `row_to_message` 不变.
+    fn row_to_message_with_seq(
+        row: &rusqlite::Row<'_>,
+    ) -> rusqlite::Result<(ChatMessage, i64)> {
+        let message = Self::row_to_message(row)?;
+        let sequence: i64 = row.get(15)?;
+        Ok((message, sequence))
+    }
 }
 
 fn opt_bool_to_int(value: Option<bool>) -> Option<i64> {
@@ -515,3 +616,153 @@ fn opt_bool_to_int(value: Option<bool>) -> Option<i64> {
 fn int_to_opt_bool(value: Option<i64>) -> Option<bool> {
     value.map(|v| v != 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message(id: &str, role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            id: id.to_string(),
+            role: role.to_string(),
+            content: content.to_string(),
+            llm_content: None,
+            system_reminder_directory: None,
+            timestamp: "2026-06-21T00:00:00Z".to_string(),
+            is_loading: None,
+            tool_call_id: None,
+            tool_name: None,
+            tool_data: None,
+            tool_input: None,
+            tool_calls: None,
+            reasoning: None,
+            is_completed: None,
+            is_collapsed: None,
+        }
+    }
+
+    async fn seed_thread(manager: &ThreadManager, thread_id: &str, n_messages: usize) {
+        manager
+            .create_thread(
+                AgentId("test-agent".to_string()),
+                "test thread".to_string(),
+            )
+            .await
+            .expect("create_thread");
+        // 注意: create_thread 已经用 default 实现生成 thread_id, 这里覆盖.
+        // 简化测试: 用直接 SQL 插入控制 thread_id.
+        {
+            let conn = manager.lock_conn();
+            conn.execute(
+                "INSERT OR REPLACE INTO threads (thread_id, agent_id, title, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![thread_id, "test-agent", "test thread", 0_i64, 0_i64],
+            )
+            .unwrap();
+        }
+        for i in 0..n_messages {
+            manager
+                .add_message(thread_id, make_message(&format!("msg-{i}"), "user", &format!("body {i}")))
+                .await
+                .expect("add_message");
+        }
+    }
+
+    #[tokio::test]
+    async fn page_returns_latest_n_when_before_is_none() {
+        let manager = ThreadManager::for_tests();
+        seed_thread(&manager, "t1", 25).await;
+
+        let page = manager
+            .get_thread_messages_page("t1", None, 10)
+            .await
+            .expect("page");
+
+        assert_eq!(page.messages.len(), 10);
+        // ASC 排序 ── 最后一条应是 msg-24, 第一条应是 msg-15.
+        assert_eq!(page.messages.first().unwrap().id, "msg-15");
+        assert_eq!(page.messages.last().unwrap().id, "msg-24");
+        assert!(page.has_more, "25 条数据取最近 10 条, 还有 15 条未拉");
+        assert_eq!(page.oldest_sequence, Some(16)); // msg-15 是第 16 条 (sequence 从 1 起)
+    }
+
+    #[tokio::test]
+    async fn page_cursor_walks_backward() {
+        let manager = ThreadManager::for_tests();
+        seed_thread(&manager, "t2", 25).await;
+
+        let first = manager
+            .get_thread_messages_page("t2", None, 10)
+            .await
+            .unwrap();
+        let cursor = first.oldest_sequence.unwrap();
+
+        let second = manager
+            .get_thread_messages_page("t2", Some(cursor), 10)
+            .await
+            .unwrap();
+
+        assert_eq!(second.messages.len(), 10);
+        assert_eq!(second.messages.first().unwrap().id, "msg-5");
+        assert_eq!(second.messages.last().unwrap().id, "msg-14");
+        assert!(second.has_more, "拉了 20 条还剩 5 条");
+    }
+
+    #[tokio::test]
+    async fn page_reaches_top_marks_has_more_false() {
+        let manager = ThreadManager::for_tests();
+        seed_thread(&manager, "t3", 8).await;
+
+        let page = manager
+            .get_thread_messages_page("t3", None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(page.messages.len(), 8);
+        assert!(!page.has_more, "全部拉完就没有更早历史");
+        assert_eq!(page.oldest_sequence, Some(1));
+    }
+
+    #[tokio::test]
+    async fn page_empty_thread_returns_empty() {
+        let manager = ThreadManager::for_tests();
+        {
+            let conn = manager.lock_conn();
+            conn.execute(
+                "INSERT INTO threads (thread_id, agent_id, title, created_at, updated_at)
+                 VALUES ('t4', 'test-agent', 'empty', 0, 0)",
+                [],
+            )
+            .unwrap();
+        }
+
+        let page = manager
+            .get_thread_messages_page("t4", None, 10)
+            .await
+            .unwrap();
+        assert!(page.messages.is_empty());
+        assert!(!page.has_more);
+        assert_eq!(page.oldest_sequence, None);
+    }
+
+    #[tokio::test]
+    async fn page_limit_clamp() {
+        let manager = ThreadManager::for_tests();
+        seed_thread(&manager, "t5", 5).await;
+
+        // limit=0 应被 clamp 到 1
+        let page = manager
+            .get_thread_messages_page("t5", None, 0)
+            .await
+            .unwrap();
+        assert_eq!(page.messages.len(), 1);
+
+        // limit > 1000 应被 clamp 到 1000 (这里只有 5 条数据, 实际返回 5)
+        let page = manager
+            .get_thread_messages_page("t5", None, 10_000)
+            .await
+            .unwrap();
+        assert_eq!(page.messages.len(), 5);
+    }
+}
+

--- a/app/flowix-web/features/agent/components/agent-root.tsx
+++ b/app/flowix-web/features/agent/components/agent-root.tsx
@@ -1,4 +1,5 @@
 ﻿import { useRef, useEffect, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChatMessage as ChatMessageComponent } from "@features/agent/components/chat-message";
 import { CodexInputbox, FlowixInputbox } from "@features/agent/components/agent-inputbox";
 import { AgentWelcome } from "@features/agent/components/agent-welcome";
@@ -127,7 +128,9 @@ function MacAgentHeader({ onClosePanel, onSelectThread }: AgentHeaderProps) {
 const EMPTY_MESSAGES: ChatMessage[] = [];
 
 export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
-	const messagesEndRef = useRef<HTMLDivElement>(null);
+	// Layer 3: 虚拟滚动 ── scrollRef 既作 useVirtualizer 的 getScrollElement,
+	// 也用于自动滚动 (替代旧 messagesEndRef.scrollIntoView 路径).
+	const scrollRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	// 浠呬綔涓?鏈厤缃?鈫?璺宠浆鍋忓ソ璁剧疆"鐨?gate, 涓嶅啀淇濈暀 agent instance:
 	// 鍚庣 chat 鏃舵寜闇€璇?ai_config.json銆?
@@ -155,6 +158,14 @@ export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
 	const stopMessageStream = useChatStore((s) => s.stopStream);
 	const setPendingPrompt = useChatStore((s) => s.setPendingPrompt);
 	const loadThread = useChatStore((s) => s.loadThread);
+	const loadMoreHistory = useChatStore((s) => s.loadMoreHistory);
+	const hasMoreHistory = useChatStore((s) => {
+		const tid =
+			getAgentRole(s.activeAgentRoleKey).runtime === "codex"
+				? s.activeCodexThreadId
+				: s.activeThreadId;
+		return tid ? s.threadStates[tid]?.hasMoreHistory ?? false : false;
+	});
 	const loadThreadList = useChatStore((s) => s.loadThreadList);
 	const loadCodexThread = useChatStore((s) => s.loadCodexThread);
 	const loadCodexThreadList = useChatStore((s) => s.loadCodexThreadList);
@@ -219,6 +230,30 @@ export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
 	// chain keeps the head stable, a replace swaps it out.
 	// 鍙紦瀛橀鏉?id 鑰屴笉鏄暣鏁扮粍 鈥?ref 鍐欏叆鏄?O(1) 瀛楃涓? 涓嶇敤鍦?	// 姣?chunk hot path 涓婂仛 ChatMessage[] 鐨勫紩鐢ㄤ紶閫掋€?
 	const prevFirstIdRef = useRef<string | undefined>(undefined);
+	// Layer 3: 用户手动向上滚后不强制 follow 到底 ── 距离底部 < 120px
+	// 视作"还在底部", 流式时自动 follow; 否则保持视口不动. 120px 比
+	// 80px 宽松一点是给"用户刚滑动了一下还没到内容深处"留缓冲.
+	const FOLLOW_BOTTOM_THRESHOLD_PX = 120;
+	const isNearBottomRef = useRef(true);
+
+	// Layer 3: useVirtualizer 动态测量. estimateSize=140 是常见单条消息
+	// 平均高度的保守估计 (短文本 60-100px, 中等 markdown 150-300px,
+	// 工具调用单行 ~40px). overscan=8 给上下各预渲 8 条, 平滑滚动
+	// 不出现空白. measureElement 自动跟踪每条实际高度 ── 流式时
+	// pending assistant 高度持续变化也能自动 re-layout, lazy 加载的
+	// 代码块完成后高度跳变同样会被自动重测.
+	const virtualizer = useVirtualizer({
+		count: messages.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => 140,
+		overscan: 8,
+		measureElement: (el) => el.getBoundingClientRect().height,
+		// 用 message id 作 key, 切换 thread 时 React 能正确复用 / 卸载
+		// 虚拟项. 默认是 index, 在 prepend (Layer 4 分页) 场景下 index
+		// 会偏移导致全部重新挂载, 用 id 避免.
+		getItemKey: (index) => messages[index]?.id ?? index,
+	});
+
 	useEffect(() => {
 		const prevId = prevFirstIdRef.current;
 		const nextId = messages[0]?.id;
@@ -228,7 +263,8 @@ export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
 		// instantly (no smooth animation) so the user lands on the
 		// latest message instead of the top of a long history.
 		if (prevId === undefined && nextId !== undefined) {
-			messagesEndRef.current?.scrollIntoView({ block: "end" });
+			virtualizer.scrollToIndex(messages.length - 1, { align: "end" });
+			isNearBottomRef.current = true;
 			return;
 		}
 		// Cleared (new conversation / cleared thread): no scroll.
@@ -239,8 +275,106 @@ export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
 		if (prevId !== nextId) return;
 
 		// Streaming / new messages: smooth follow.
-		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-	}, [messages]);
+		// Layer 3: 仅当用户在底部附近时 follow, 否则保持视口不动.
+		if (isNearBottomRef.current) {
+			virtualizer.scrollToIndex(messages.length - 1, {
+				align: "end",
+				behavior: "smooth",
+			});
+		}
+	}, [messages, virtualizer]);
+
+	// Layer 3: 监听 scroll 事件, 维护 isNearBottomRef. 用 passive listener,
+	// 直接读 scrollTop / scrollHeight / clientHeight, 不进 React state ──
+	// 避免每次滚动都触发 re-render.
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		const handler = () => {
+			const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+			isNearBottomRef.current = distance < FOLLOW_BOTTOM_THRESHOLD_PX;
+		};
+		el.addEventListener("scroll", handler, { passive: true });
+		// 初始判定一次, 避免首屏未触发 scroll 时 isNearBottomRef 默认值
+		// 与实际位置不符.
+		handler();
+		return () => el.removeEventListener("scroll", handler);
+	}, []);
+
+	// Layer 4: 顶部触达检测 + prepend 后视口稳定.
+	// 触发条件: 滚动距离顶部 < 200px AND has-more AND 当前是 flowix runtime
+	// (codex 走独立 codex_thread_get, 本期不分页).
+	//
+	// 视口稳定算法: prepend 前快照 scrollHeight → prepend 完成 resolve 后,
+	// 新 scrollHeight 增大, 把当前 scrollTop 也按相同 delta 推下, 用户视口
+	// 里看到的内容位置不变. requestAnimationFrame 让 react-virtual 先把新
+	// 虚拟项 measure 好再写 scrollTop, 否则会跳一下.
+	//
+	// **F-1 修复 (thread-switch race)**: handler 启动时 `activeThreadId` 闭
+	// 包捕获的是 effect setup 时的值. IPC in-flight 期间用户切 thread/role
+	// 会导致 rAF 回调里 `el` 已是新 thread 的 scroll container, 此时再写
+	// `el.scrollTop` 会把新 thread 的视口推到错位置. 修复: 在 `.then` 与
+	// rAF 回调里用 `useChatStore.getState()` 直读最新 active thread, 与
+	// 触发时的 tidAtCall 比对, 不一致就 bail.
+	//
+	// **F-2 修复 (rapid-fire scroll / scroll-during-IPC)**: 之前快照了
+	// `beforeScrollTop` 并在 rAF 写回 `beforeScrollTop + delta`. 但若 IPC
+	// 期间用户滚了几 px (触屏 / 鼠标惯性), 用陈旧的 beforeScrollTop 算
+	// 出的新 scrollTop 会"甩"用户, 视觉上短暂跳一下. 修复: 不快照
+	// scrollTop, rAF 内现读 `el.scrollTop + delta`, 把视口锚到"当前看到
+	// 的内容 + delta 偏移", 在用户停在顶部 / 滚到中间 / 自动 follow 到底
+	// 三种情况下都自然正确. 多次触发的并发由 `loadMoreHistory` 自身的
+	// `loadingMore` 守门保证只有一个 fetch 跑 ── 其它 handler 调用走
+	// `loadMoreHistory` 立即返 false, 不调度 rAF.
+	const PREFETCH_TOP_THRESHOLD_PX = 200;
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		// codex runtime 不分页 ── Layer 4 仅对 flowix 后端做了 SQL 分页, codex
+		// 走 codex_history::get_session 仍是全量, 不必拦截.
+		if (activeRole.runtime === "codex") return;
+
+		const handler = () => {
+			if (el.scrollTop > PREFETCH_TOP_THRESHOLD_PX) return;
+			if (!hasMoreHistory) return;
+			if (!activeThreadId) return;
+
+			const tidAtCall = activeThreadId;
+			const beforeScrollHeight = el.scrollHeight;
+
+			// F-1: 直读 store 最新 active thread, 不依赖闭包 ── 闭包里的
+			// `activeThreadId` 是 effect 重建时捕获的旧值, IPC in-flight
+			// 期间用户切 thread 不会反映到这里. 用 `getState()` 拿实时值.
+			const isStillOnSameThread = (): boolean => {
+				const s = useChatStore.getState();
+				const role = getAgentRole(s.activeAgentRoleKey);
+				const currentTid =
+					role.runtime === "codex" ? s.activeCodexThreadId : s.activeThreadId;
+				return currentTid === tidAtCall;
+			};
+
+			void loadMoreHistory(tidAtCall).then((loaded) => {
+				if (!loaded) return;
+				if (!isStillOnSameThread()) return;
+				// 等一帧让 react-virtual 应用新 messages → 重新 measure 虚拟项 → 总高度更新.
+				requestAnimationFrame(() => {
+					if (!isStillOnSameThread()) return;
+					const afterScrollHeight = el.scrollHeight;
+					const delta = afterScrollHeight - beforeScrollHeight;
+					if (delta > 0) {
+						// F-2: 不用陈旧 beforeScrollTop, 用当前 scrollTop + delta ──
+						// 视口锚到"用户当前看到的内容", 不甩回 IPC 前的位置.
+						el.scrollTop = el.scrollTop + delta;
+					}
+				});
+			});
+		};
+		el.addEventListener("scroll", handler, { passive: true });
+		// 初次进入也判定一次 (短 thread 可能首屏就触顶, 自动加载更多).
+		handler();
+		return () => el.removeEventListener("scroll", handler);
+	}, [activeThreadId, activeRole.runtime, hasMoreHistory, loadMoreHistory]);
+
 
 	// 鎶婃枃鏈€佽繘 chat store 鐨?pendingPrompt, 鐢?Inputbox 鑷繁鐨?effect 璋?	// setInput 鍐欏叆鍙楁帶 state 鈥?鐩存帴鏀?DOM ref 浼氳 value={input} 鐨勫彈鎺?	// textarea 鍦ㄤ笅娆℃覆鏌撴椂鍥炴粴, 鍙戦€佹寜閽殑 disabled 涔熻涓嶅埌鍊笺€?
 	const setInputValue = (value: string) => {
@@ -275,13 +409,51 @@ export function AgentChatRoot({ onSendMessage, onClosePanel }: AgentRootProps) {
 				<MacAgentHeader onClosePanel={onClosePanel} onSelectThread={handleSelectThread} />
 			)}
 
-			<div className="flex-1 overflow-y-auto scrollbar overflow-x-hidden">
+			<div
+				ref={scrollRef}
+				className="flex-1 overflow-y-auto scrollbar overflow-x-hidden"
+			>
 				{messages.length > 0 ? (
-					<div className="space-y-1.5 px-6 py-4">
-						{messages.map((message) => (
-							<ChatMessageComponent key={message.id} message={message} />
-						))}
-						<div ref={messagesEndRef} />
+					// Layer 3: 虚拟滚动容器. 外层 div 高度 = virtualizer.getTotalSize(),
+					// 内部用 absolute + transform 定位每个虚拟项 ── DOM 节点数从
+					// O(N) 降到 O(overscan + visible) ≈ 20 左右, 1MB 历史 (~500 条)
+					// 首屏从 1.5-4s 降到 <200ms.
+					//
+					// padding 处理: 横向 px-6 留在外层 scroll 容器 (不影响虚拟化
+					// 高度); 纵向 py-4 + 行间距 space-y-1.5 通过给虚拟内层
+					// 顶 / 底 padding + 每项 wrapper 加 pb-1.5 等效模拟. 不直接
+					// 用 padding 包裹虚拟项, 否则 absolute 定位会被 padding 偏移
+					// 顶掉, getTotalSize 算出来的总高与实际不一致.
+					<div className="px-6">
+						<div
+							style={{
+								height: virtualizer.getTotalSize() + 32, // +32 = py-4 上下各 16px
+								position: "relative",
+								paddingTop: 16,
+							}}
+						>
+							{virtualizer.getVirtualItems().map((vi) => {
+								const message = messages[vi.index];
+								if (!message) return null;
+								return (
+									<div
+										key={vi.key}
+										data-index={vi.index}
+										ref={virtualizer.measureElement}
+										style={{
+											position: "absolute",
+											top: 0,
+											left: 0,
+											width: "100%",
+											transform: `translateY(${vi.start + 16}px)`,
+											paddingBottom: 6, // ≈ space-y-1.5 (0.375rem)
+										}}
+									>
+										<ChatMessageComponent message={message} />
+									</div>
+								);
+							})}
+						</div>
 					</div>
 				) : (
 					<AgentWelcome onSelectPrompt={setInputValue} />

--- a/app/flowix-web/features/agent/components/chat-message.tsx
+++ b/app/flowix-web/features/agent/components/chat-message.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import {
   MessageUser,
@@ -8,8 +9,7 @@ import {
 } from "@features/agent/components/messages";
 
 interface ChatMessageProps {
-  message?: ChatMessageType;
-  fallback?: React.ReactNode;
+  message: ChatMessageType;
 }
 
 // Role to component mapping
@@ -22,16 +22,35 @@ const roleToComponent = {
   end: MessageEnd,
 };
 
-export function ChatMessage({ message, fallback }: ChatMessageProps) {
-  // Render fallback when no message
-  if (fallback && !message) {
-    return <>{fallback}</>;
-  }
+// memo 浅比较的字段 ── 与 `types/index.ts:168-185` 的 `ChatMessage` 展示字段对齐.
+// 只比较影响渲染的字段, 跳过 `timestamp / llmContent / systemReminder*` 等
+// 与 UI 无关字段 (timestamp 在 user/assistant 当前未渲染; llmContent 仅给后端).
+//
+// **必须严格对齐**: 漏字段 → 组件不更新; 多比较字段 → 浪费 CPU 但行为正确.
+// 后续若 ChatMessage 新增展示字段, 同步更新此处.
+function isSameMessage(a: ChatMessageType, b: ChatMessageType): boolean {
+  return (
+    a === b ||
+    (a.id === b.id &&
+      a.role === b.role &&
+      a.content === b.content &&
+      a.reasoning === b.reasoning &&
+      a.toolData === b.toolData &&
+      a.toolName === b.toolName &&
+      a.toolCallId === b.toolCallId &&
+      a.toolInput === b.toolInput &&
+      a.toolCalls === b.toolCalls &&
+      a.isLoading === b.isLoading &&
+      a.isCompleted === b.isCompleted &&
+      a.isCollapsed === b.isCollapsed)
+  );
+}
 
-  if (!message) {
-    return null;
-  }
-
+// Layer 1: 用 React.memo 包裹, 避免流式 chunk 触发 messages 数组引用变化时
+// 让全部历史 message 子树重新进入 react-markdown 重 parse. chat-store 内
+// `closedMessages.map(m => m.id === pending ? {...m, content: ...} : m)`
+// 对未命中分支直接返回 m, 对象引用稳定 → 此处浅比较能正确跳过.
+function ChatMessageInner({ message }: ChatMessageProps) {
   // Look up the component by role
   const Component = roleToComponent[message.role];
 
@@ -41,3 +60,8 @@ export function ChatMessage({ message, fallback }: ChatMessageProps) {
 
   return <Component message={message} />;
 }
+
+export const ChatMessage = memo(ChatMessageInner, (prev, next) => {
+  if (prev.message === next.message) return true;
+  return isSameMessage(prev.message, next.message);
+});

--- a/app/flowix-web/features/agent/components/messages/markdown-renderer.tsx
+++ b/app/flowix-web/features/agent/components/messages/markdown-renderer.tsx
@@ -1,5 +1,5 @@
-import { isValidElement, lazy, Suspense } from "react";
-import ReactMarkdown from "react-markdown";
+import { isValidElement, lazy, memo, Suspense } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { openNoteByDeepLink } from "@platform/open-target";
@@ -22,7 +22,7 @@ const CodeBlock = lazy(async () => {
         customStyle={{
           margin: 0,
           padding: "0.5rem 0.75rem 0.75rem",
-          background: "var(--code-block-bg)",
+          background: "var(--editor-block-bg)",
           borderRadius: "0.5rem",
           border: "1px solid var(--border)",
           fontSize: "0.78rem",
@@ -87,7 +87,7 @@ const WRAPPER_CLASS =
   // padding: 0 0.4rem / border-radius: 0.4rem / font-size: 0.78rem /
   // background: var(--code-bg) / color: var(--foreground) / font-family: inherit. 跨三处
   // (Tiptap 正文 / AgentThreadCard 卡片 / 右栏 Agent 消息体) 走同一套 token. 块 code 仍
-  // 走 --code-block-bg + 0.5rem 圆角区分视觉权重. 
+  // 走 --editor-block-bg + 0.5rem 圆角区分视觉权重.
   "[&_code]:bg-[var(--code-bg)] [&_code]:px-[0.4rem] [&_code]:py-0 [&_code]:rounded-[0.4rem] [&_code]:border [&_code]:border-border [&_code]:text-[0.78rem] [&_code]:text-foreground [&_code]:font-sans " +
   // pre 内的 code 还原: 透明背景, 无边框, 字号回到 pre 字号, color 走 muted-foreground
   // (与 tiptap pre code 行为一致: padding: 0, 走父级 pre 背景)
@@ -111,94 +111,116 @@ const CODE_BLOCK_CLASS = "relative my-3 rounded-lg overflow-hidden border border
 // 收口, 套两层会出现"双边框 + 圆角错位"。
 const TABLE_WRAPPER_CLASS = "overflow-x-auto my-3 bg-transparent";
 
-export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+// Layer 1: components / urlTransform / onClick handler 都提到 module 顶层
+// 常量 ── 否则每次 render 都是 inline 新对象, 顶层 React.memo 拿到的
+// content 即便相同, 内部 ReactMarkdown 也会因 components 引用变化重新
+// 走它内部的 reconcile (这一层不是 memo 决定的, 但提到顶层有零成本).
+//
+// 真正决定 memo 是否生效的是 `MarkdownRenderer` 自身的 props 比较 ── 只比
+// `content`. WRAPPER_CLASS 等已是常量, content 不变 → memo 跳过.
+
+const MARKDOWN_COMPONENTS: Components = {
+  a({ href, children, ...props }) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+    );
+  },
+  pre({ children }) {
+    // react-markdown v10 仍会为围栏代码块包一层默认 <pre>。
+    // 我们在下面的 `code` 覆盖里已经返回了 <div class="code-block">，
+    // 把它再套进 <pre> 会形成两套盒模型叠加（外层 <pre> 的
+    // font-size / line-height / overflow-x: auto 与 SyntaxHighlighter
+    // 的 customStyle 重复），导致代码块视觉上出现「重影 / 双边框」。
+    // 因此当 <pre> 的子节点是 code-block 容器时，直接透传 children。
+    const child = Array.isArray(children) ? children[0] : children;
+    if (
+      isValidElement(child) &&
+      child.type === "div" &&
+      (child.props as { className?: string })?.className === CODE_BLOCK_CLASS
+    ) {
+      return <>{child}</>;
+    }
+    return <pre>{children}</pre>;
+  },
+  code({ className, children, ...props }) {
+    const match = /language-(\w+)/.exec(className || "");
+    const isInline = !match;
+    const language = match ? match[1] : "";
+
+    if (isInline) {
+      return <code {...props}>{children}</code>;
+    }
+
+    return (
+      <div className={CODE_BLOCK_CLASS}>
+        {/* 懒加载: 250KB+ chunk 只在第一个带代码块的消息到达时拉。
+            Suspense fallback 走 inline <pre>, 加载完无缝替换 ── 用户
+            视觉上不会感知 (chat 流本来就是逐 token 出现)。 */}
+        <Suspense
+          fallback={
+            <pre className="m-0 px-3 py-2 text-[0.78rem] text-[var(--muted-foreground)] font-sans">
+              {String(children).replace(/\n$/, "")}
+            </pre>
+          }
+        >
+          <CodeBlock language={language}>
+            {String(children).replace(/\n$/, "")}
+          </CodeBlock>
+        </Suspense>
+      </div>
+    );
+  },
+  table({ children }) {
+    return (
+      <div className={TABLE_WRAPPER_CLASS}>
+        <table>{children}</table>
+      </div>
+    );
+  },
+};
+
+// react-markdown v10 默认 urlTransform 只放行 http/https/mailto/tel,
+// `flowix://` 会被清空成 `""`。 透传自定义 scheme 之后,
+// 下文自定义的 <a> 才能在点击时拿到完整 href。
+const urlTransform = (url: string) => url;
+
+const remarkPlugins = [remarkGfm];
+
+// 委托: 点击 Agent 输出里的 flowix:// 深链时, 走 `openByTarget` 统一管线
+// (跟 noteReference 双击 / 单 instance 二次启动 / 外部深链同一入口)。
+// 不影响 http(s) 链接 — 那些由 <a> 默认行为走浏览器/OS。
+function handleWrapperClick(e: React.MouseEvent<HTMLDivElement>) {
+  const a = (e.target as HTMLElement).closest<HTMLAnchorElement>(
+    'a[href^="flowix://"]'
+  );
+  if (!a) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const href = a.getAttribute("href");
+  if (href) void openNoteByDeepLink(href);
+}
+
+function MarkdownRendererInner({ content }: MarkdownRendererProps) {
   return (
-    <div
-      className={WRAPPER_CLASS}
-      // 委托: 点击 Agent 输出里的 flowix:// 深链时, 走 `openByTarget` 统一管线
-      // (跟 noteReference 双击 / 单 instance 二次启动 / 外部深链同一入口)。
-      // 不影响 http(s) 链接 — 那些由 <a> 默认行为走浏览器/OS。
-      onClick={(e) => {
-        const a = (e.target as HTMLElement).closest<HTMLAnchorElement>(
-          'a[href^="flowix://"]'
-        );
-        if (!a) return;
-        e.preventDefault();
-        e.stopPropagation();
-        const href = a.getAttribute("href");
-        if (href) void openNoteByDeepLink(href);
-      }}
-    >
+    <div className={WRAPPER_CLASS} onClick={handleWrapperClick}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        // react-markdown v10 默认 urlTransform 只放行 http/https/mailto/tel,
-        // `flowix://` 会被清空成 `""`。 透传自定义 scheme 之后,
-        // 下文自定义的 <a> 才能在点击时拿到完整 href。
-        urlTransform={(url) => url}
-        components={{
-          a({ href, children, ...props }) {
-            return (
-              <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
-                {children}
-              </a>
-            );
-          },
-          pre({ children }) {
-            // react-markdown v10 仍会为围栏代码块包一层默认 <pre>。
-            // 我们在下面的 `code` 覆盖里已经返回了 <div class="code-block">，
-            // 把它再套进 <pre> 会形成两套盒模型叠加（外层 <pre> 的
-            // font-size / line-height / overflow-x: auto 与 SyntaxHighlighter
-            // 的 customStyle 重复），导致代码块视觉上出现「重影 / 双边框」。
-            // 因此当 <pre> 的子节点是 code-block 容器时，直接透传 children。
-            const child = Array.isArray(children) ? children[0] : children;
-            if (
-              isValidElement(child) &&
-              child.type === "div" &&
-              (child.props as { className?: string })?.className === CODE_BLOCK_CLASS
-            ) {
-              return <>{child}</>;
-            }
-            return <pre>{children}</pre>;
-          },
-          code({ className, children, ...props }) {
-            const match = /language-(\w+)/.exec(className || "");
-            const isInline = !match;
-            const language = match ? match[1] : "";
-
-            if (isInline) {
-              return <code {...props}>{children}</code>;
-            }
-
-            return (
-              <div className={CODE_BLOCK_CLASS}>
-                {/* 懒加载: 250KB+ chunk 只在第一个带代码块的消息到达时拉。
-                    Suspense fallback 走 inline <pre>, 加载完无缝替换 ── 用户
-                    视觉上不会感知 (chat 流本来就是逐 token 出现)。 */}
-                <Suspense
-                  fallback={
-                    <pre className="m-0 px-3 py-2 text-[0.78rem] text-[var(--muted-foreground)] font-sans">
-                      {String(children).replace(/\n$/, "")}
-                    </pre>
-                  }
-                >
-                  <CodeBlock language={language}>
-                    {String(children).replace(/\n$/, "")}
-                  </CodeBlock>
-                </Suspense>
-              </div>
-            );
-          },
-          table({ children }) {
-            return (
-              <div className={TABLE_WRAPPER_CLASS}>
-                <table>{children}</table>
-              </div>
-            );
-          },
-        }}
+        remarkPlugins={remarkPlugins}
+        urlTransform={urlTransform}
+        components={MARKDOWN_COMPONENTS}
       >
         {content}
       </ReactMarkdown>
     </div>
   );
 }
+
+// Layer 1: 用 React.memo 包裹, 只在 content 变化时重 parse markdown.
+// 流式场景下 (chat-store `applyTextChunk` 仅修改 pending assistant 那一条),
+// 其它历史消息的 content 引用稳定, 此处直接跳过, 历史 N 条消息零 markdown
+// 重 parse 开销.
+export const MarkdownRenderer = memo(
+  MarkdownRendererInner,
+  (prev, next) => prev.content === next.content
+);

--- a/app/flowix-web/features/agent/components/messages/message-assistant.tsx
+++ b/app/flowix-web/features/agent/components/messages/message-assistant.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import {
   getAgentMessageVisibleContent,
@@ -9,7 +10,7 @@ interface MessageAssistantProps {
   message: ChatMessageType;
 }
 
-export function MessageAssistant({ message }: MessageAssistantProps) {
+function MessageAssistantInner({ message }: MessageAssistantProps) {
   if (!shouldRenderAgentMessage(message)) {
     return null;
   }
@@ -25,3 +26,15 @@ export function MessageAssistant({ message }: MessageAssistantProps) {
     </div>
   );
 }
+
+// Layer 1: memo 保险层. 外层 ChatMessage 已 memo, 但 MessageAssistant 也可能
+// 被其它地方直接复用 (chat-message.tsx 字典分发外). content 不变则跳过 ──
+// 与 MarkdownRenderer 自身的 memo 形成两层保护.
+export const MessageAssistant = memo(
+  MessageAssistantInner,
+  (prev, next) =>
+    prev.message === next.message ||
+    (prev.message.id === next.message.id &&
+      prev.message.content === next.message.content &&
+      prev.message.role === next.message.role)
+);

--- a/app/flowix-web/features/agent/components/messages/message-end.tsx
+++ b/app/flowix-web/features/agent/components/messages/message-end.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import { getAgentMessageVisibleContent } from "@features/agent/message/agent-message";
 
@@ -5,7 +6,7 @@ interface MessageEndProps {
   message: ChatMessageType;
 }
 
-export function MessageEnd({ message }: MessageEndProps) {
+function MessageEndInner({ message }: MessageEndProps) {
   const visibleContent = getAgentMessageVisibleContent(message);
 
   return (
@@ -18,3 +19,12 @@ export function MessageEnd({ message }: MessageEndProps) {
     </div>
   );
 }
+
+// Layer 1: end 行只渲染纯文本, content 不变则跳过.
+export const MessageEnd = memo(
+  MessageEndInner,
+  (prev, next) =>
+    prev.message === next.message ||
+    (prev.message.id === next.message.id &&
+      prev.message.content === next.message.content)
+);

--- a/app/flowix-web/features/agent/components/messages/message-reasoning.tsx
+++ b/app/flowix-web/features/agent/components/messages/message-reasoning.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import { useSettingsStore } from "@features/shell";
@@ -11,7 +12,7 @@ interface MessageReasoningProps {
   message: ChatMessageType;
 }
 
-export function MessageReasoning({ message }: MessageReasoningProps) {
+function MessageReasoningInner({ message }: MessageReasoningProps) {
   const reasoningCollapsed = useSettingsStore((state) => state.reasoningCollapsed);
   const toggleReasoningCollapsed = useSettingsStore((state) => state.toggleReasoningCollapsed);
 
@@ -42,3 +43,17 @@ export function MessageReasoning({ message }: MessageReasoningProps) {
     </div>
   );
 }
+
+// Layer 1: 当 message props 不变时跳过. 内部消费的 `reasoningCollapsed` /
+// `toggleReasoningCollapsed` 来自 useSettingsStore, store 变化时 zustand
+// 会自然触发该组件重渲, 与外层 memo 不冲突 (memo 只挡 props 相同时的
+// 父级 re-render, 不挡 hook 订阅触发的内部更新).
+export const MessageReasoning = memo(
+  MessageReasoningInner,
+  (prev, next) =>
+    prev.message === next.message ||
+    (prev.message.id === next.message.id &&
+      prev.message.content === next.message.content &&
+      prev.message.reasoning === next.message.reasoning &&
+      prev.message.isCompleted === next.message.isCompleted)
+);

--- a/app/flowix-web/features/agent/components/messages/message-tool.tsx
+++ b/app/flowix-web/features/agent/components/messages/message-tool.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { memo } from "react";
 import type { ChatMessage } from "@/types";
 import { getToolIconPath } from "@features/agent/message/tools";
 import { createAgentMessageViewModel } from "@features/agent/message/agent-message";
 import { Loader2 } from "lucide-react";
 
-export function MessageTool({ message }: { message: ChatMessage }) {
+function MessageToolInner({ message }: { message: ChatMessage }) {
   const iconPath = getToolIconPath(message.toolName);
   const isLoading = Boolean(message.isLoading);
   const messageView = createAgentMessageViewModel(message);
@@ -39,3 +40,20 @@ export function MessageTool({ message }: { message: ChatMessage }) {
     </div>
   );
 }
+
+// Layer 1: tool 行的展示依赖 toolName/toolInput/toolData/isLoading.
+// `createAgentMessageViewModel` 对这些字段消费, 不变则视图不变.
+// toolInput / toolCalls 是对象引用 ── 浅比较即可: chat-store
+// `applyToolCallChunk` / `applyToolResultChunk` 命中目标行才重建对象,
+// 其它行引用稳定.
+export const MessageTool = memo(
+  MessageToolInner,
+  (prev, next) =>
+    prev.message === next.message ||
+    (prev.message.id === next.message.id &&
+      prev.message.toolName === next.message.toolName &&
+      prev.message.toolData === next.message.toolData &&
+      prev.message.toolInput === next.message.toolInput &&
+      prev.message.toolCalls === next.message.toolCalls &&
+      prev.message.isLoading === next.message.isLoading)
+);

--- a/app/flowix-web/features/agent/components/messages/message-user.tsx
+++ b/app/flowix-web/features/agent/components/messages/message-user.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { ChatMessage as ChatMessageType } from "@/types";
 import { parseYamlMeta } from "@features/agent/message/parse";
 import { truncateStart } from "@features/agent/message/format";
@@ -9,7 +10,7 @@ interface MessageUserProps {
   message: ChatMessageType;
 }
 
-export function MessageUser({ message }: MessageUserProps) {
+function MessageUserInner({ message }: MessageUserProps) {
   // Parse YAML meta + optional `<citation>` block. The citation lives at the
   // top of the payload and is rendered as a card above the bubble body,
   // matching the inputbox's pre-send preview.
@@ -39,3 +40,13 @@ export function MessageUser({ message }: MessageUserProps) {
     </>
   );
 }
+
+// Layer 1: user 消息一旦发送 content 不再变化, memo 之后历史 user 消息
+// 永远跳过 re-render.
+export const MessageUser = memo(
+  MessageUserInner,
+  (prev, next) =>
+    prev.message === next.message ||
+    (prev.message.id === next.message.id &&
+      prev.message.content === next.message.content)
+);

--- a/app/flowix-web/features/agent/store/agent-access-store.ts
+++ b/app/flowix-web/features/agent/store/agent-access-store.ts
@@ -171,3 +171,4 @@ function extractReason(e: unknown): string | null {
   }
   return null;
 }
+

--- a/app/flowix-web/features/agent/store/chat-store.ts
+++ b/app/flowix-web/features/agent/store/chat-store.ts
@@ -140,6 +140,28 @@ function mergeHistoricalMessages(existing: ChatMessage[], historical: ChatMessag
 }
 
 /**
+ * Layer 4: 把更早的历史 prepend 到 in-memory messages 头.
+ * 用 id 去重 (older 来自 SQL, in-memory existing 可能也已经有 ── 例如
+ * 用户连续触发两次顶部加载, 第二次 fetch 已被首次响应覆盖). prepend
+ * 一定不会与 in-flight streaming chunk 冲突 (流式 chunk 永远 append 到末尾,
+ * 流式 pending assistant id 是 `assistant-${Date.now()}`, 不可能与历史
+ * 已存 id 重复).
+ */
+function prependHistoricalMessages(existing: ChatMessage[], older: ChatMessage[]): ChatMessage[] {
+  if (older.length === 0) return existing;
+  if (existing.length === 0) return older;
+  const seenIds = new Set(existing.map((m) => m.id));
+  const fresh = older.filter((m) => !seenIds.has(m.id));
+  if (fresh.length === 0) return existing;
+  return [...fresh, ...existing];
+}
+
+/** Layer 4: 单页大小. 100 条覆盖典型 thread 的"最近一屏所需"且 IPC payload
+ * 控制在 ~100KB. 用户向上翻页时每页同样 100 条. 太小会触发频繁加载, 太大
+ * 又退化成全量. */
+const HISTORY_PAGE_SIZE = 100;
+
+/**
  * 每个 thread 独立的运行态 ── 不再绑在"当前 active thread"上, 让 A
  * 对话在后台跑 / B 对话在前面写 / 重入 A 看到全部最新消息都能成立。
  *
@@ -157,6 +179,13 @@ export interface ThreadState {
   isLoading: boolean;
   pendingAssistantId: string | null;
   pendingReasoningId: string | null;
+  /** Layer 4: 当前 in-memory messages 中最早一条的 sequence (作下一页 cursor).
+   *  null = 尚未通过分页加载 (兼容旧 loadThread 全量路径) 或 thread 为空. */
+  oldestSequence: number | null;
+  /** Layer 4: 是否还有更早的历史可加载. false → 顶部不再 prefetch. */
+  hasMoreHistory: boolean;
+  /** Layer 4: 防止并发触发顶部加载 ── true 时 loadMoreHistory 直接 early return. */
+  loadingMore: boolean;
 }
 
 function emptyThreadState(): ThreadState {
@@ -165,6 +194,9 @@ function emptyThreadState(): ThreadState {
     isLoading: false,
     pendingAssistantId: null,
     pendingReasoningId: null,
+    oldestSequence: null,
+    hasMoreHistory: false,
+    loadingMore: false,
   };
 }
 
@@ -217,9 +249,16 @@ export interface ChatStore {
   setPendingPrompt: (prompt: string | undefined) => void;
   consumePendingPrompt: () => string | undefined;
   setPendingCitation: (citation: string | undefined) => void;
-  consumePendingCitation: () => string | undefined;
   loadThreadList: () => Promise<void>;
   loadThread: (threadId: string) => Promise<void>;
+  /**
+   * Layer 4: 顶部加载更早的历史. 用 threadStates[tid].oldestSequence 作 cursor,
+   * 一次拉 PAGE_SIZE 条 prepend 到 messages 头. 并发保护: loadingMore=true 时
+   * 直接 early return.
+   * 返回值: 是否真的加载了新数据 (false 表示无更多 / 已在加载中 / thread 缺失).
+   * 调用方 (agent-root.tsx 顶部触达) 可用返回值决定是否调整 scrollOffset.
+   */
+  loadMoreHistory: (threadId: string) => Promise<boolean>;
   loadCodexThreadList: () => Promise<void>;
   loadCodexThread: (threadId: string) => Promise<void>;
   loadThreadCache: (threadId: string) => Promise<void>;
@@ -385,13 +424,6 @@ export const useChatStore = create<ChatStore>()(
           return pendingPrompt;
         },
         setPendingCitation: (citation) => set({ pendingCitation: citation }),
-        consumePendingCitation: () => {
-          const { pendingCitation } = get();
-          if (pendingCitation !== undefined) {
-            set({ pendingCitation: undefined });
-          }
-          return pendingCitation;
-        },
 
         loadThreadList: async () => {
           try {
@@ -404,13 +436,15 @@ export const useChatStore = create<ChatStore>()(
 
         loadThread: async (threadId) => {
           try {
-            const thread = await agent.getThread(threadId);
+            // Layer 4: 用分页 API 取最近 HISTORY_PAGE_SIZE 条, 而非全量.
+            // 1MB / 500 条 thread 的 IPC payload 从 ~1MB 降到 ~100KB.
+            const page = await agent.getThreadPage(threadId, null, HISTORY_PAGE_SIZE);
             const threadInfo =
               get().threadList.find((item) => item.threadId === threadId) ??
               (await agent.listThreads()).find((item) => item.threadId === threadId);
             // Drop empty assistant messages that older sessions may have
             // persisted — they render as blank cards and add no value.
-            const messages = thread.messages.filter((m) => !isEmptyAssistantMessage(m));
+            const messages = page.messages.filter((m) => !isEmptyAssistantMessage(m));
             set((state) => {
               const existing = state.threadStates[threadId] ?? emptyThreadState();
               // 以 `message.id` 去重 merge ── 若该 thread 当前正在跑
@@ -431,6 +465,8 @@ export const useChatStore = create<ChatStore>()(
                   [threadId]: {
                     ...existing,
                     messages: merged,
+                    oldestSequence: page.oldestSequence,
+                    hasMoreHistory: page.hasMore,
                   },
                 },
                 currentThreadTitle: threadInfo?.title ?? '未命名对话',
@@ -438,6 +474,82 @@ export const useChatStore = create<ChatStore>()(
             });
           } catch (err) {
             console.error('Failed to load thread:', err);
+          }
+        },
+
+        loadMoreHistory: async (threadId) => {
+          // Layer 4: 顶部触达 → 加载更早一页. 并发保护 + has-more 守门 + cursor 检查.
+          const stateBefore = get().threadStates[threadId];
+          if (!stateBefore) return false;
+          if (stateBefore.loadingMore) return false;
+          if (!stateBefore.hasMoreHistory) return false;
+          if (stateBefore.oldestSequence == null) return false;
+
+          // 置 loadingMore=true (并发互斥); fetch 完后清除.
+          set((state) => {
+            const st = state.threadStates[threadId];
+            if (!st) return state;
+            return {
+              threadStates: {
+                ...state.threadStates,
+                [threadId]: { ...st, loadingMore: true },
+              },
+            };
+          });
+
+          try {
+            const page = await agent.getThreadPage(
+              threadId,
+              stateBefore.oldestSequence,
+              HISTORY_PAGE_SIZE,
+            );
+            const olderMessages = page.messages.filter((m) => !isEmptyAssistantMessage(m));
+            if (olderMessages.length === 0 && !page.hasMore) {
+              // 已到顶 ── 仅更新 hasMoreHistory=false 即可, 不动 messages.
+              set((state) => {
+                const st = state.threadStates[threadId];
+                if (!st) return state;
+                return {
+                  threadStates: {
+                    ...state.threadStates,
+                    [threadId]: { ...st, hasMoreHistory: false, loadingMore: false },
+                  },
+                };
+              });
+              return false;
+            }
+            set((state) => {
+              const st = state.threadStates[threadId];
+              if (!st) return state;
+              const prepended = prependHistoricalMessages(st.messages, olderMessages);
+              return {
+                threadStates: {
+                  ...state.threadStates,
+                  [threadId]: {
+                    ...st,
+                    messages: prepended,
+                    oldestSequence: page.oldestSequence ?? st.oldestSequence,
+                    hasMoreHistory: page.hasMore,
+                    loadingMore: false,
+                  },
+                },
+              };
+            });
+            return true;
+          } catch (err) {
+            console.error('Failed to load more history:', err);
+            // 失败也要清 loadingMore, 否则后续永远不再触发.
+            set((state) => {
+              const st = state.threadStates[threadId];
+              if (!st) return state;
+              return {
+                threadStates: {
+                  ...state.threadStates,
+                  [threadId]: { ...st, loadingMore: false },
+                },
+              };
+            });
+            return false;
           }
         },
 
@@ -773,6 +885,11 @@ export const useChatStore = create<ChatStore>()(
           const { activeThreadId, activeCodexThreadId } = get();
           const activeId = role.runtime === 'codex' ? activeCodexThreadId : activeThreadId;
           if (!activeId) return;
+          // Layer 2: 停流前先 flush 流式缓冲 ── 否则缓冲里残留的 token
+          // 会在下一帧 rAF 被 apply 到刚停的 thread, 形成"已停但又冒一段
+          // 文字出来"的撕裂. 同步 flush 后再发 stopChatStream IPC, 后端
+          // emit StreamEnd 收敛 isLoading.
+          flushStreamingBuffersSync();
           try {
             await agent.stopChatStream(activeId);
           } catch (err) {
@@ -785,8 +902,47 @@ export const useChatStore = create<ChatStore>()(
         },
 
         dispatchAgentChunk: (chunk) => {
+          const tid = chunk.thread_id;
+
+          // Layer 2: text / reasoning 走 rAF 节流; 其它 chunk 进入前先同步
+          // flush 缓冲, 保证后端发出的顺序 (text → tool_call → text →
+          // tool_result → text) 在 UI 上呈现的顺序与时序一致.
+          //
+          // 节流粒度: rAF (~16ms = 60fps). 一帧内多次 text chunk 合并成
+          // 一次 setState, 把"每个 token 触发整 messages 数组 spread +
+          // 所有子组件 re-render" 收敛到"每帧最多一次". 文本最终内容
+          // 完全等价 ── 缓冲只是把 N 段 token 拼成一段, applyTextChunk
+          // 的语义不变.
+          switch (chunk.kind) {
+            case 'text': {
+              // 跳过纯空白 chunk ── 与旧 chat-store.ts:322 同形.
+              if (!chunk.text || !chunk.text.trim()) return;
+              appendStreamingBuffer(textBuffer, tid, chunk.text);
+              scheduleStreamingFlush();
+              return;
+            }
+            case 'reasoning': {
+              appendStreamingBuffer(reasoningBuffer, tid, chunk.text);
+              scheduleStreamingFlush();
+              return;
+            }
+            case 'tool_call':
+            case 'tool_result':
+            case 'error':
+            case 'stream_end':
+              // 这些 chunk 频率低且必须立刻可见, 不走节流;
+              // 但必须先 flush 缓冲, 否则文本顺序错乱 ──
+              // 例: 一段 assistant 文本被 tool_call 切走时,
+              // 缓冲里残留的文字应该先落到 pending assistant,
+              // 再让 tool_call 走 close 逻辑.
+              flushStreamingBuffersSync();
+              break;
+            // stream_start 无需 flush ── 流刚开始时缓冲必空.
+            case 'stream_start':
+              break;
+          }
+
           set((state) => {
-            const tid = chunk.thread_id;
             const st = state.threadStates[tid] ?? emptyThreadState();
             switch (chunk.kind) {
               case 'stream_start':
@@ -808,35 +964,6 @@ export const useChatStore = create<ChatStore>()(
                     },
                   },
                 };
-              case 'text': {
-                // 跳过纯空白 chunk ── 与旧 chat-store.ts:322 同形。
-                if (!chunk.text || !chunk.text.trim()) return state;
-                const next = applyTextChunk(st, chunk.text);
-                return {
-                  threadStates: {
-                    ...state.threadStates,
-                    [tid]: {
-                      ...st,
-                      messages: next.messages,
-                      pendingAssistantId: next.pendingAssistantId,
-                      pendingReasoningId: null, // text 落地后 reasoning 行 closed
-                    },
-                  },
-                };
-              }
-              case 'reasoning': {
-                const next = applyReasoningChunk(st, chunk.text);
-                return {
-                  threadStates: {
-                    ...state.threadStates,
-                    [tid]: {
-                      ...st,
-                      messages: next.messages,
-                      pendingReasoningId: next.pendingReasoningId,
-                    },
-                  },
-                };
-              }
               case 'tool_call': {
                 const next = applyToolCallChunk(st, chunk.id, chunk.name, chunk.input);
                 return {
@@ -868,6 +995,8 @@ export const useChatStore = create<ChatStore>()(
                   },
                 };
               }
+              default:
+                return state;
             }
           });
         },
@@ -931,6 +1060,97 @@ interface ApplyResult {
   messages: ChatMessage[];
   pendingAssistantId: string | null;
   pendingReasoningId: string | null;
+}
+
+// ───────────────────────── Layer 2: 流式 chunk rAF 节流 ─────────────────────
+//
+// 后端 `agent.rs:1128-1148` 是每个 LLM token 一次 emit, 典型 100-300
+// chunk/s. 直接每个 chunk 调 zustand `set` 会让 messages 数组引用每帧
+// 重建多次, 配合 Layer 1 的 React.memo 虽然能跳过历史消息子树,
+// 但 store 自身的订阅 + selector 比较仍会被频繁触发. rAF 节流把它压到
+// 60fps 上限, 主线程消耗骤减.
+//
+// 缓冲设计: 每个 thread_id 一个 string buffer (按 thread 分桶, 不同 thread
+// 后台并跑互不干扰). flush 时把每个 thread 的累积文本一次性 apply ──
+// applyTextChunk 内部 `m.content + text` 与多次 append 等价, 不影响最终内容.
+//
+// 顺序保证: tool_call/result/error/stream_end 进入 dispatchAgentChunk 时
+// **同步** 先 flush 缓冲, 保证 "text → tool_call" 的顺序在 UI 上不错乱.
+
+const textBuffer = new Map<string, string>();
+const reasoningBuffer = new Map<string, string>();
+let pendingRafId: number | null = null;
+
+function appendStreamingBuffer(buf: Map<string, string>, tid: string, text: string): void {
+  buf.set(tid, (buf.get(tid) ?? '') + text);
+}
+
+function scheduleStreamingFlush(): void {
+  if (pendingRafId != null) return;
+  // SSR / 测试环境兜底 ── 没有 requestAnimationFrame 时直接 microtask flush.
+  // 当前是 Tauri WebView 内, 一定有 rAF, 但留容错避免单元测试崩.
+  const raf =
+    typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number;
+  pendingRafId = raf(() => {
+    pendingRafId = null;
+    flushStreamingBuffersSync();
+  });
+}
+
+/** 同步把所有缓冲 flush 到 store. 入口:
+ *  - rAF 触发 (流式正常路径)
+ *  - tool_call / tool_result / error / stream_end chunk 进入前 (顺序保证)
+ *  - stopStream 调用时 (避免缓冲泄漏到下一轮对话) */
+function flushStreamingBuffersSync(): void {
+  if (textBuffer.size === 0 && reasoningBuffer.size === 0) {
+    if (pendingRafId != null) {
+      if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(pendingRafId);
+      pendingRafId = null;
+    }
+    return;
+  }
+  // 取出缓冲快照, 清空 ── 避免 set 回调内再次 flush 时重入.
+  const textSnapshot = new Map(textBuffer);
+  const reasoningSnapshot = new Map(reasoningBuffer);
+  textBuffer.clear();
+  reasoningBuffer.clear();
+  if (pendingRafId != null) {
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(pendingRafId);
+    pendingRafId = null;
+  }
+
+  useChatStore.setState((state) => {
+    const threadStates: ThreadsMap = { ...state.threadStates };
+    // reasoning 先 apply ── 与旧 store 时序一致 (reasoning chunk 先于
+    // text 出现; text chunk 落地时会 close reasoning 行). 但 rAF 内
+    // 两者可能同帧到达, 用 reasoning-first 顺序保证 close 语义正确.
+    for (const [tid, text] of reasoningSnapshot) {
+      const st = threadStates[tid];
+      // thread 已被清掉 (切换 / 删除) ── 直接丢弃缓冲, 与"chunk 到达时
+      // thread 已无对应 state"行为一致.
+      if (!st) continue;
+      const next = applyReasoningChunk(st, text);
+      threadStates[tid] = {
+        ...st,
+        messages: next.messages,
+        pendingReasoningId: next.pendingReasoningId,
+      };
+    }
+    for (const [tid, text] of textSnapshot) {
+      const st = threadStates[tid];
+      if (!st) continue;
+      const next = applyTextChunk(st, text);
+      threadStates[tid] = {
+        ...st,
+        messages: next.messages,
+        pendingAssistantId: next.pendingAssistantId,
+        pendingReasoningId: null, // text 落地后 reasoning 行 closed
+      };
+    }
+    return { threadStates };
+  });
 }
 
 /** 在 `text` chunk 上做 append ── 与旧 chat-store.ts:319-348 同形,

--- a/app/flowix-web/features/document/components/document-titlebar-mac.tsx
+++ b/app/flowix-web/features/document/components/document-titlebar-mac.tsx
@@ -72,7 +72,7 @@ export function DocumentTitlebarMac({
     <div
       data-tauri-drag-region
       className={`h-12 shrink-0 ${isSidebarHidden ? 'pl-[90px]' : 'pl-0'} pr-0 z-[50] flex items-center`}
-      style={{ backgroundImage: 'linear-gradient(to bottom, var(--bg-titlebar), transparent)' }}
+      style={{ backgroundImage: 'linear-gradient(to bottom, var(--bg-titlebar), var(--document-bg))' }}
     >
       <div className="flex shrink-0 items-center gap-1">
         {isSidebarHidden && (

--- a/app/flowix-web/features/document/components/document-titlebar-shared.tsx
+++ b/app/flowix-web/features/document/components/document-titlebar-shared.tsx
@@ -10,7 +10,7 @@ import {
   FileMdIcon,
   FileDocIcon,
   ClockIcon,
-  TrashIcon,
+  TrashSimpleIcon,
   BoxArrowDownIcon,
 } from '@phosphor-icons/react';
 import {
@@ -219,7 +219,7 @@ export function MemoColorPicker({
               onClick={clear}
               className={`relative h-7 w-7 rounded-md transition-colors ${
                 colors.length === 0
-                  ? 'ring-2 ring-[var(--muted)]'
+                  ? 'ring-1 ring-[var(--muted)]'
                   : 'hover:bg-[var(--muted)]'
               }`}
             >
@@ -231,25 +231,24 @@ export function MemoColorPicker({
           {MEMO_COLORS.map((c) => {
             const isSelected = selected.has(c);
             return (
-              <Tooltip key={c} content={COLOR_LABELS[c]}>
-                <button
-                  type="button"
-                  aria-label={COLOR_LABELS[c]}
-                  aria-pressed={isSelected}
-                  onClick={() => toggle(c)}
-                  className="relative h-7 w-7 rounded-md transition-transform hover:scale-110"
-                  style={{ backgroundColor: MEMO_COLOR_HEX[c] }}
-                >
-                  {isSelected && (
-                    <span
-                      aria-hidden="true"
-                      className="pointer-events-none absolute inset-0 flex items-center justify-center text-white opacity-70"
-                    >
-                      <Check className="h-2.5 w-2.5" strokeWidth={3} />
-                    </span>
-                  )}
-                </button>
-              </Tooltip>
+              <button
+                key={c}
+                type="button"
+                aria-label={COLOR_LABELS[c]}
+                aria-pressed={isSelected}
+                onClick={() => toggle(c)}
+                className="relative h-7 w-7 rounded-md transition-transform hover:scale-110"
+                style={{ backgroundColor: MEMO_COLOR_HEX[c] }}
+              >
+                {isSelected && (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0 flex items-center justify-center text-white opacity-70"
+                  >
+                    <Check className="h-2.5 w-2.5" strokeWidth={3} />
+                  </span>
+                )}
+              </button>
             );
           })}
         </div>
@@ -570,9 +569,9 @@ export function MemoActions({
           />
           <DropdownMenuItem
             onClick={onRequestDeleteMemo}
-            className="flex items-center cursor-pointer rounded-md px-2 hover:bg-[var(--muted)] text-[var(--destructive)]"
+            className="flex items-center cursor-pointer rounded-md px-2 hover:bg-[var(--muted)] hover:text-[var(--destructive)]"
           >
-            <TrashIcon className="w-4 h-4 mr-2" /> 删除
+            <TrashSimpleIcon className="w-4 h-4 mr-2" /> 删除
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/app/flowix-web/features/document/components/document-titlebar-win.tsx
+++ b/app/flowix-web/features/document/components/document-titlebar-win.tsx
@@ -72,7 +72,7 @@ export function DocumentTitlebarWin({
     <div
       data-tauri-drag-region
       className={`h-9 shrink-0 pl-2 z-[50] flex items-center ${isAgentPanelVisible ? 'pr-0' : 'pr-[126px]'}`}
-      style={{ backgroundImage: 'linear-gradient(to bottom, var(--bg-titlebar), transparent)' }}
+      style={{ backgroundImage: 'linear-gradient(to bottom, var(--bg-titlebar), var(--document-bg))' }}
     >
       <div className="flex shrink-0 items-center gap-1">
         {isSidebarHidden && (

--- a/app/flowix-web/features/editor/components/drag-context-menu/actions.ts
+++ b/app/flowix-web/features/editor/components/drag-context-menu/actions.ts
@@ -14,8 +14,12 @@ import type { BlockMenuItem } from '@features/editor/components/drag-context-men
 // menu-pin extension's transaction metadata API. The decoration is
 // rendered by ProseMirror's view-update pipeline (see extensions/menu-pin.ts),
 // not by direct DOM mutation, so it survives any external class-stripping.
-export function pinBlock(editor: Editor, pos: number): void {
-  editor.view.dispatch(editor.view.state.tr.setMeta(menuPinPluginKey, pos))
+export function pinBlock(editor: Editor, info: CurrentBlockInfo): void {
+  editor.view.dispatch(editor.view.state.tr.setMeta(menuPinPluginKey, {
+    pos: info.pos,
+    typeName: info.typeName,
+    nodeSize: info.nodeSize,
+  }))
 }
 
 export function unpinBlock(editor: Editor): void {
@@ -45,7 +49,7 @@ export function applyMenuItem(editor: Editor, item: BlockMenuItem): void {
  *    those node types use for keyboard delete.
  *  - TextSelection / cursor: `deleteRange` from the block's open-token
  *    position to its end, deleting the entire block (heading, paragraph,
- *    listItem, tableCell, codeBlock, etc.).
+ *    listItem, codeBlock, etc.). Tables use the table extension command.
  * Returns true if a delete was actually attempted.
  */
 export function deleteBlock(editor: Editor): boolean {
@@ -56,6 +60,10 @@ export function deleteBlock(editor: Editor): boolean {
   }
   const info: CurrentBlockInfo | null = getCurrentBlockInfo(editor)
   if (info) {
+    if (info.typeName === 'table') {
+      editor.chain().focus().deleteTable().run()
+      return true
+    }
     editor.chain().focus().deleteRange({ from: info.pos, to: info.pos + info.nodeSize }).run()
     return true
   }

--- a/app/flowix-web/features/editor/components/drag-context-menu/block-action-menu.tsx
+++ b/app/flowix-web/features/editor/components/drag-context-menu/block-action-menu.tsx
@@ -1,0 +1,83 @@
+import { Fragment, type CSSProperties, type KeyboardEvent, type MouseEvent } from 'react'
+import { Kbd } from '@shared/ui/shortcut-kbd'
+import { useSelectedItemScroll } from '@features/editor/extensions/shared/use-selected-item-scroll'
+import type { BlockMenuAction } from '@features/editor/components/drag-context-menu/block-menu-actions'
+
+interface BlockActionMenuProps {
+  actions: BlockMenuAction[]
+  selectedIndex: number
+  menuRef: (node: HTMLDivElement | null) => void
+  style: CSSProperties
+  onHover: (index: number) => void
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void
+}
+
+export function BlockActionMenu({
+  actions,
+  selectedIndex,
+  menuRef,
+  style,
+  onHover,
+  onKeyDown,
+}: BlockActionMenuProps) {
+  const { scrollerRef, itemRefs } = useSelectedItemScroll({
+    items: actions,
+    selectedIndex,
+  })
+
+  const handleItemMouseMove = (
+    event: MouseEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (event.movementX === 0 && event.movementY === 0) return
+    onHover(index)
+  }
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Block actions"
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      className="fixed z-50 bg-[var(--card)] border border-[var(--border)] rounded-lg shadow-lg p-1"
+      style={style}
+    >
+      <div ref={scrollerRef}>
+        {actions.map((action, index) => {
+          const isDanger = action.group === 'danger'
+          return (
+            <Fragment key={action.id}>
+              {index > 0 && actions[index - 1]?.group !== action.group && (
+                <hr className="my-1 mx-2 border-t border-[var(--divider)]" />
+              )}
+              <button
+                ref={(node) => {
+                  itemRefs.current[index] = node
+                }}
+                type="button"
+                role="menuitem"
+                onMouseMove={(event) => handleItemMouseMove(event, index)}
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                  action.onSelect()
+                }}
+                className={`relative flex items-center w-full px-3 py-1.5 text-sm cursor-pointer hover:bg-[var(--muted)] active:bg-[var(--accent)] text-left rounded text-[var(--foreground)]${index === selectedIndex ? ' bg-[var(--muted)]' : ''}${isDanger ? ' hover:text-[var(--destructive)]' : ''}`}
+                style={{ gap: 12 }}
+              >
+                {action.icon}
+                <span className="min-w-0 flex-1">{action.label}</span>
+                {action.shortcut && (
+                  <Kbd
+                    chord={action.shortcut}
+                    className="shrink-0 text-[var(--muted-foreground)]"
+                  />
+                )}
+              </button>
+            </Fragment>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/flowix-web/features/editor/components/drag-context-menu/block-info.ts
+++ b/app/flowix-web/features/editor/components/drag-context-menu/block-info.ts
@@ -35,6 +35,20 @@ export interface CurrentBlockInfo {
   dom: HTMLElement
 }
 
+const WRAPPING_BLOCK_TYPES = new Set([
+  'blockquote',
+  'table',
+  'bulletList',
+  'orderedList',
+  'taskList',
+])
+
+const LIST_BLOCK_TYPES = new Set([
+  'bulletList',
+  'orderedList',
+  'taskList',
+])
+
 /** Resolve the block the editor's current selection is on (PM-native, not DOM). */
 export function getCurrentBlockInfo(editor: Editor): CurrentBlockInfo | null {
   const view = editor.view
@@ -57,30 +71,47 @@ export function getCurrentBlockInfo(editor: Editor): CurrentBlockInfo | null {
     }
   }
 
-  // TextSelection / cursor: $from.parent is the immediate block the cursor
-  // lives in (paragraph, heading, listItem, tableCell, blockquote, etc.).
+  // TextSelection / cursor: use the nearest wrapping block when the cursor
+  // is inside one. This keeps the handle's visual anchor and the command /
+  // drag target aligned for lists, tables, and quotes.
+  // Plain text blocks (paragraph, heading, codeBlock, etc.) fall back to the
+  // immediate parent.
   const { $from } = selection
-  const parent = $from.parent
-  if (!parent) return null
-  // `$from.depth` is the depth of the parent (1 for top-level blocks,
-  // 2 for listItem/taskItem, 4 for tableCell, etc.). `$from.start(depth)`
-  // returns the position just inside the parent's open token, so subtract
-  // 1 to land on the open token itself — that's the position `view.nodeDOM`
-  // uses to return the parent's outer DOM. (Using `$from.before(1)` would
-  // hardcode depth 1, which for a listItem cursor resolves to the *first*
-  // listItem of the list, not the one the cursor is in.)
   if ($from.depth < 1) return null
-  const pos = $from.start($from.depth) - 1
+  const depth = getTargetBlockDepth($from)
+  const node = $from.node(depth)
+  const pos = $from.before(depth)
   const dom = view.nodeDOM(pos)
   if (!(dom instanceof HTMLElement)) return null
   return {
-    node: parent,
-    typeName: parent.type.name,
-    attrs: parent.attrs,
+    node,
+    typeName: node.type.name,
+    attrs: node.attrs,
     pos,
-    nodeSize: parent.nodeSize,
+    nodeSize: node.nodeSize,
     dom,
   }
+}
+
+function getTargetBlockDepth($from: { depth: number; node: (depth: number) => PMNode }): number {
+  for (let depth = $from.depth; depth >= 1; depth--) {
+    if ($from.node(depth).type.name === 'table') {
+      return depth
+    }
+  }
+
+  for (let depth = 1; depth <= $from.depth; depth++) {
+    if (LIST_BLOCK_TYPES.has($from.node(depth).type.name)) {
+      return depth
+    }
+  }
+
+  for (let depth = $from.depth; depth >= 1; depth--) {
+    if (WRAPPING_BLOCK_TYPES.has($from.node(depth).type.name)) {
+      return depth
+    }
+  }
+  return $from.depth
 }
 
 /**
@@ -107,13 +138,38 @@ export function selectBlockContent(editor: Editor): void {
     return
   }
 
-  const from = info.pos + 1
-  const to = info.pos + info.nodeSize - 1
-  if (from > to) {
-    // Empty block: nothing to select, but make sure focus lands at the
-    // start of the block so the menu's transform commands act on it.
-    editor.chain().focus().setTextSelection(from).run()
+  const textblockSelection = getFirstTextblockSelection(info)
+  if (textblockSelection) {
+    editor.chain().focus().setTextSelection(textblockSelection).run()
     return
   }
-  editor.chain().focus().setTextSelection({ from, to }).run()
+
+  if (NodeSelection.isSelectable(info.node)) {
+    editor.chain().focus().setNodeSelection(info.pos).run()
+  }
+}
+
+function getFirstTextblockSelection(info: CurrentBlockInfo): { from: number; to: number } | null {
+  if (!isWrappingBlock(info)) {
+    return getNodeTextSelection(info.pos, info.node)
+  }
+
+  let selection: { from: number; to: number } | null = null
+  info.node.descendants((node, relativePos) => {
+    if (!node.isTextblock) return true
+    selection = getNodeTextSelection(info.pos + 1 + relativePos, node)
+    return false
+  })
+  return selection
+}
+
+function getNodeTextSelection(pos: number, node: PMNode): { from: number; to: number } | null {
+  if (!node.isTextblock) return null
+  const from = pos + 1
+  const to = pos + node.nodeSize - 1
+  return { from, to }
+}
+
+function isWrappingBlock(info: CurrentBlockInfo): boolean {
+  return WRAPPING_BLOCK_TYPES.has(info.typeName)
 }

--- a/app/flowix-web/features/editor/components/drag-context-menu/block-menu-actions.tsx
+++ b/app/flowix-web/features/editor/components/drag-context-menu/block-menu-actions.tsx
@@ -1,0 +1,49 @@
+import { useMemo, type ReactNode } from 'react'
+import { TrashSimpleIcon } from '@phosphor-icons/react'
+import {
+  headingMenuItems,
+  listMenuItems,
+  type BlockMenuItem,
+} from '@features/editor/components/drag-context-menu/items'
+
+export type BlockMenuActionGroup = 'heading' | 'list' | 'danger'
+
+export interface BlockMenuAction {
+  id: string
+  group: BlockMenuActionGroup
+  icon: ReactNode
+  label: string
+  shortcut?: string
+  onSelect: () => void
+}
+
+export function useBlockMenuActions(
+  onMenuItem: (item: BlockMenuItem) => void,
+  onDelete: () => void,
+): BlockMenuAction[] {
+  return useMemo(() => [
+    ...headingMenuItems.map((item): BlockMenuAction => ({
+      id: item.kind === 'heading' ? `h${item.level}` : 'paragraph',
+      group: 'heading',
+      icon: item.icon,
+      label: item.display,
+      shortcut: item.shortcut,
+      onSelect: () => onMenuItem(item),
+    })),
+    ...listMenuItems.map((item): BlockMenuAction => ({
+      id: item.listType,
+      group: 'list',
+      icon: item.icon,
+      label: item.display,
+      shortcut: item.shortcut,
+      onSelect: () => onMenuItem(item),
+    })),
+    {
+      id: 'delete',
+      group: 'danger',
+      icon: <TrashSimpleIcon size={16} weight="bold" />,
+      label: '删除',
+      onSelect: onDelete,
+    },
+  ], [onMenuItem, onDelete])
+}

--- a/app/flowix-web/features/editor/components/drag-context-menu/icons.tsx
+++ b/app/flowix-web/features/editor/components/drag-context-menu/icons.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode } from 'react'
-import type { Editor } from '@tiptap/core'
 import {
   TextHOneIcon,
   TextHTwoIcon,
   TextHThreeIcon,
   TextHFourIcon,
 } from '@phosphor-icons/react'
-import { getCurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
+import type { CurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
 
 /**
  * Handle's icon. Pure render-time derivation from
@@ -43,8 +42,7 @@ export function DefaultDragIcon() {
 
 /** H1–H4 Phosphor icon when the cursor sits in a matching heading,
  *  otherwise the default grip glyph. */
-export function renderDragIcon(editor: Editor): ReactNode {
-  const info = getCurrentBlockInfo(editor)
+export function renderDragIcon(info: CurrentBlockInfo | null): ReactNode {
   if (info?.typeName === 'heading') {
     const level = info.attrs.level
     if (level === 1 || level === 2 || level === 3 || level === 4) {

--- a/app/flowix-web/features/editor/components/drag-context-menu/index.tsx
+++ b/app/flowix-web/features/editor/components/drag-context-menu/index.tsx
@@ -1,7 +1,5 @@
-import { Fragment, useEffect, useState, useRef, type ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type KeyboardEvent } from 'react'
 import type { Editor } from '@tiptap/core'
-import { TrashSimpleIcon } from '@phosphor-icons/react'
-import { Kbd } from '@shared/ui/kbd'
 import { getCurrentBlockInfo, selectBlockContent } from '@features/editor/components/drag-context-menu/block-info'
 import {
   applyMenuItem,
@@ -9,27 +7,33 @@ import {
   pinBlock,
   unpinBlock,
 } from '@features/editor/components/drag-context-menu/actions'
-import { renderDragIcon } from '@features/editor/components/drag-context-menu/icons'
 import {
-  headingMenuItems,
-  listMenuItems,
-  type BlockMenuItem,
-} from '@features/editor/components/drag-context-menu/items'
-import { computeHandlePosition } from '@features/editor/components/drag-context-menu/positioning'
+  BLOCK_DRAG_MIME,
+  endBlockDrag,
+  startBlockDrag,
+} from '@features/editor/extensions/block-drag'
+import { renderDragIcon } from '@features/editor/components/drag-context-menu/icons'
+import type { BlockMenuItem } from '@features/editor/components/drag-context-menu/items'
 import { HANDLE_SIZE } from '@features/editor/components/drag-context-menu/style'
+import { useDragHandlePosition } from '@features/editor/components/drag-context-menu/use-drag-handle-position'
+import { BlockActionMenu } from '@features/editor/components/drag-context-menu/block-action-menu'
+import { useBlockMenuActions } from '@features/editor/components/drag-context-menu/block-menu-actions'
 import { useUserSettingsStore } from '@features/preferences/store/user-settings-store'
 
 interface DragContextMenuProps {
   editor: Editor
 }
 
-interface DragHandleState {
-  visible: boolean
-  x: number
-  y: number
+interface MenuViewportPosition {
+  left: number
+  top: number
 }
 
-const MENU_MIN_SPACE = 300
+const MENU_GAP = 8
+const MENU_VIEWPORT_PADDING = 8
+// 底部状态栏 (h-6 = 24px) 会遮挡太贴近视口底部的弹窗 —
+// 留出 30px 净空让菜单至少停在状态栏之上约 6px。
+const MENU_BOTTOM_CLEARANCE = 30
 
 export function DragContextMenu({ editor }: DragContextMenuProps) {
   // 字体/行高 (Preferences → Format) — 走窄 selector, 只在这两值变化时
@@ -38,86 +42,88 @@ export function DragContextMenu({ editor }: DragContextMenuProps) {
   const fontSize = useUserSettingsStore((s) => s.settings.format.fontSize)
   const lineHeight = useUserSettingsStore((s) => s.settings.format.lineHeight)
 
-  const [state, setState] = useState<DragHandleState>({
-    visible: false,
-    x: 0,
-    y: 0,
-  })
   const [showMenu, setShowMenu] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
-  const [menuPosition, setMenuPosition] = useState<'bottom' | 'top'>('bottom')
+  const [menuPosition, setMenuPosition] = useState<MenuViewportPosition | null>(null)
+  const [selectedIndex, setSelectedIndex] = useState(0)
   const containerRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const ignoreBlur = useRef(false)
+  const menuOpenRef = useRef(false)
+  const didStartDrag = useRef(false)
+  const state = useDragHandlePosition(editor, fontSize, lineHeight, ignoreBlur, menuOpenRef)
 
-  // Track the editor: re-anchor the handle on every selectionUpdate, focus,
-  // scroll, and (debounced) resize. Hide on blur unless the user is mid-click.
   useEffect(() => {
-    if (!editor?.view?.dom) return
+    menuOpenRef.current = showMenu
+  }, [showMenu])
 
-    let mounted = true
-    let rafId: number | null = null
-    let frameSkip = 0
-
-    const updateDragHandle = () => {
-      if (!mounted) return
-      const pos = computeHandlePosition(editor, fontSize, lineHeight)
-      if (!pos || !pos.visible) {
-        setState(prev => ({ ...prev, visible: false }))
-        return
-      }
-      setState({ visible: true, x: pos.x, y: pos.y })
-    }
-
-    const handleScroll = () => {
-      if (rafId) return
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        updateDragHandle()
-      })
-    }
-
+  useEffect(() => {
     const handleBlur = () => {
       if (!ignoreBlur.current) {
-        setState(prev => ({ ...prev, visible: false }))
-        // Editor lost focus: the menu's target is no longer actionable,
-        // so drop the pin to keep the visual honest.
+        setShowMenu(false)
+        setIsHovered(false)
         unpinBlock(editor)
       }
     }
 
-    editor.on('selectionUpdate', updateDragHandle)
-    editor.on('focus', updateDragHandle)
     editor.on('blur', handleBlur)
+    return () => {
+      editor.off('blur', handleBlur)
+    }
+  }, [editor])
+
+  const updateMenuPosition = useCallback(() => {
+    if (!containerRef.current || !menuRef.current) return
+    const handleRect = containerRef.current.getBoundingClientRect()
+    const menuRect = menuRef.current.getBoundingClientRect()
+    const rightSpace = window.innerWidth - handleRect.right - MENU_GAP - MENU_VIEWPORT_PADDING
+    const leftSpace = handleRect.left - MENU_GAP - MENU_VIEWPORT_PADDING
+    const placeRight = rightSpace >= menuRect.width || rightSpace >= leftSpace
+    const preferredLeft = placeRight
+      ? handleRect.right + MENU_GAP
+      : handleRect.left - MENU_GAP - menuRect.width
+    const preferredTop = handleRect.top
+
+    setMenuPosition({
+      left: clamp(preferredLeft, MENU_VIEWPORT_PADDING, window.innerWidth - menuRect.width - MENU_VIEWPORT_PADDING),
+      top: clamp(preferredTop, MENU_VIEWPORT_PADDING, window.innerHeight - menuRect.height - MENU_BOTTOM_CLEARANCE),
+    })
+  }, [])
+
+  const closeMenu = useCallback(() => {
+    unpinBlock(editor)
+    setMenuPosition(null)
+    setIsHovered(false)
+    setShowMenu(false)
+  }, [editor])
+
+  useLayoutEffect(() => {
+    if (!showMenu) return
+    updateMenuPosition()
+  }, [showMenu, state.x, state.y, updateMenuPosition])
+
+  useEffect(() => {
+    if (!showMenu) return
 
     const editorDom = editor.view.dom as HTMLElement
-    const scrollContainer = editorDom.closest('.markdown-editor') as HTMLElement
+    const scrollContainer = editorDom.closest('.markdown-editor') as HTMLElement | null
     const scrollTarget = scrollContainer || editorDom
-    scrollTarget.addEventListener('scroll', handleScroll, { passive: true })
+    const closeOnScroll = (event: Event) => {
+      const target = event.target
+      if (target instanceof Node && menuRef.current?.contains(target)) return
+      closeMenu()
+    }
 
-    // 3-frame skip keeps the resize handler light — the editor rarely
-    // changes size, so a low-frequency update is enough to keep the
-    // handle in sync without pegging the main thread.
-    const resizeObserver = new ResizeObserver(() => {
-      if (rafId) return
-      frameSkip++
-      if (frameSkip % 3 !== 0) return
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        updateDragHandle()
-      })
-    })
-    resizeObserver.observe(scrollContainer || editorDom)
+    scrollTarget.addEventListener('scroll', closeOnScroll, { passive: true })
+    window.addEventListener('resize', closeMenu)
+    window.addEventListener('scroll', closeOnScroll, true)
 
     return () => {
-      mounted = false
-      if (rafId) cancelAnimationFrame(rafId)
-      editor.off('selectionUpdate', updateDragHandle)
-      editor.off('focus', updateDragHandle)
-      editor.off('blur', handleBlur)
-      scrollTarget.removeEventListener('scroll', handleScroll)
-      resizeObserver.disconnect()
+      scrollTarget.removeEventListener('scroll', closeOnScroll)
+      window.removeEventListener('resize', closeMenu)
+      window.removeEventListener('scroll', closeOnScroll, true)
     }
-  }, [editor, fontSize, lineHeight])
+  }, [showMenu, editor, closeMenu])
 
   // Click outside the handle dismisses the menu + drops the pin.
   useEffect(() => {
@@ -138,7 +144,7 @@ export function DragContextMenu({ editor }: DragContextMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [showMenu, editor])
 
-  const onMenuItem = (item: BlockMenuItem) => {
+  const onMenuItem = useCallback((item: BlockMenuItem) => {
     applyMenuItem(editor, item)
     setShowMenu(false)
     // 鼠标停在菜单项上(handle 之外),hover 态必须强制清零;
@@ -148,9 +154,9 @@ export function DragContextMenu({ editor }: DragContextMenuProps) {
     // The transformed block may be at a different position; drop the pin
     // so the next selectionUpdate can re-pin to the new block.
     unpinBlock(editor)
-  }
+  }, [editor])
 
-  const onDelete = () => {
+  const onDelete = useCallback(() => {
     deleteBlock(editor)
     setShowMenu(false)
     // 同 onMenuItem: 鼠标在菜单项上(handle 外),hover 态强制清零。
@@ -158,11 +164,105 @@ export function DragContextMenu({ editor }: DragContextMenuProps) {
     // The deleted node is gone — drop the pin. The plugin's docChanged
     // handler additionally re-validates any stale pin position.
     unpinBlock(editor)
+  }, [editor])
+  const menuActions = useBlockMenuActions(onMenuItem, onDelete)
+
+  const openMenu = () => {
+    const info = getCurrentBlockInfo(editor)
+    if (info) {
+      selectBlockContent(editor)
+      pinBlock(editor, info)
+    }
+    setMenuPosition(null)
+    setIsHovered(false)
+    setSelectedIndex(0)
+    setShowMenu(true)
+  }
+
+  const selectCurrentMenuAction = () => {
+    const action = menuActions[selectedIndex]
+    if (action) action.onSelect()
+  }
+
+  const moveSelection = (direction: 1 | -1) => {
+    const count = menuActions.length
+    if (count === 0) return
+    setSelectedIndex((index) => (index + direction + count) % count)
+  }
+
+  const handleMenuKeyDown = (e: KeyboardEvent | globalThis.KeyboardEvent) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      e.stopPropagation()
+      moveSelection(-1)
+      return true
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      e.stopPropagation()
+      moveSelection(1)
+      return true
+    }
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      e.stopPropagation()
+      moveSelection(e.shiftKey ? -1 : 1)
+      return true
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.stopPropagation()
+      selectCurrentMenuAction()
+      return true
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
+      closeMenu()
+      return true
+    }
+    return false
+  }
+
+  useEffect(() => {
+    if (!showMenu) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      ignoreBlur.current = true
+      menuRef.current?.focus({ preventScroll: true })
+      window.setTimeout(() => {
+        ignoreBlur.current = false
+      }, 0)
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [showMenu])
+
+  const toggleMenu = () => {
+    if (showMenu) {
+      closeMenu()
+    } else {
+      openMenu()
+    }
+  }
+
+  const onHandleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (showMenu && handleMenuKeyDown(e)) {
+      return
+    }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      toggleMenu()
+    }
   }
 
   return (
     <div
       ref={containerRef}
+      role="button"
+      aria-haspopup="menu"
+      aria-expanded={showMenu}
+      tabIndex={state.visible ? 0 : -1}
       className={`drag-context-menu-handle${showMenu ? ' active' : ''}`}
       style={{
         position: 'absolute',
@@ -178,104 +278,74 @@ export function DragContextMenu({ editor }: DragContextMenuProps) {
         background: showMenu ? 'var(--brand)' : (isHovered ? 'var(--muted)' : 'transparent'),
         color: showMenu ? 'var(--primary-foreground)' : 'var(--brand)',
         borderRadius: '4px',
-        cursor: 'pointer',
+        cursor: showMenu ? 'pointer' : 'grab',
       }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onMouseDown={(e) => {
         ignoreBlur.current = true
+        window.setTimeout(() => {
+          ignoreBlur.current = false
+        }, 0)
         if (showMenu) {
           e.preventDefault()
         }
       }}
-      onClick={() => {
-        if (!showMenu && containerRef.current) {
-          const rect = containerRef.current.getBoundingClientRect()
-          const spaceBelow = window.innerHeight - rect.bottom
-          setMenuPosition(spaceBelow > MENU_MIN_SPACE ? 'bottom' : 'top')
+      onKeyDown={onHandleKeyDown}
+      draggable
+      onDragStart={(e) => {
+        const started = startBlockDrag(editor, state.blockInfo)
+        if (!started) {
+          e.preventDefault()
+          return
         }
-        const nextOpen = !showMenu
-        if (nextOpen) {
-          const info = getCurrentBlockInfo(editor)
-          if (info) {
-            // 1) Real editor selection (TextSelection / NodeSelection) →
-            //    browser-native ::selection styles apply.
-            selectBlockContent(editor)
-            // 2) Plugin-driven decoration (left accent bar + block tint)
-            //    via the menu-pin plugin → rendered by PM view pipeline.
-            pinBlock(editor, info.pos)
-          }
-        } else {
-          unpinBlock(editor)
-        }
-        // 菜单打开 / 关闭的同一帧内,hover 态无条件清零。
-        // 打开时背景切到 var(--brand) 不读 isHovered,所以清零无副作用。
-        // 关闭时鼠标虽然还在 handle 上,但只要用户一动鼠标 onMouseEnter
-        // 会自然把 hover 态打回 true — 而不主动恢复可以避免
-        // "脏 hover=true 跟着 showMenu 一起走"在 handle 移到新块时
-        // 把 hover 背景粘到新位置上。
+        didStartDrag.current = true
+        setShowMenu(false)
         setIsHovered(false)
-        setShowMenu(nextOpen)
-        // Clear the ignoreBlur flag at the end of the click handler.
-        // Any blur event triggered by this click's focus changes has
-        // already fired (they're synchronous with the focus change),
-        // so it saw ignoreBlur=true. Subsequent blur events — from the
-        // user clicking elsewhere — should be honored.
+        if (state.blockInfo) pinBlock(editor, state.blockInfo)
+        e.dataTransfer.effectAllowed = 'move'
+        e.dataTransfer.setData(BLOCK_DRAG_MIME, '1')
+        e.dataTransfer.setData('text/plain', '')
+      }}
+      onDragEnd={() => {
+        endBlockDrag(editor)
+        unpinBlock(editor)
+        ignoreBlur.current = false
+        window.setTimeout(() => {
+          didStartDrag.current = false
+        }, 0)
+      }}
+      onClick={() => {
+        if (didStartDrag.current) return
+        toggleMenu()
         ignoreBlur.current = false
       }}
     >
-      {renderDragIcon(editor)}
+      {renderDragIcon(state.blockInfo)}
       {showMenu && (
-        <div
-          className="absolute z-50 bg-[var(--card)] border border-[var(--border)] rounded-lg shadow-lg p-1"
-          style={{
-            left: '100%',
-            top: menuPosition === 'bottom' ? 0 : 'auto',
-            bottom: menuPosition === 'top' ? 0 : 'auto',
-            marginLeft: 8,
-            minWidth: 180,
+        <BlockActionMenu
+          actions={menuActions}
+          selectedIndex={selectedIndex}
+          menuRef={(node) => {
+            menuRef.current = node
           }}
-        >
-          {headingMenuItems.map((item) => (
-            <Fragment key={item.kind === 'heading' ? `h${item.level}` : 'paragraph'}>
-              {renderMenuButton(item.icon, item.display, item.shortcut, () => onMenuItem(item))}
-            </Fragment>
-          ))}
-          <hr className="my-1 mx-2 border-t border-[var(--divider)]" />
-          {listMenuItems.map((item) => (
-            <Fragment key={item.listType}>
-              {renderMenuButton(item.icon, item.display, item.shortcut, () => onMenuItem(item))}
-            </Fragment>
-          ))}
-          <hr className="my-1 mx-2 border-t border-[var(--divider)]" />
-          {renderMenuButton(<TrashSimpleIcon size={16} weight="bold" />, '删除', undefined, onDelete)}
-        </div>
+          style={getMenuStyle(menuPosition)}
+          onHover={setSelectedIndex}
+          onKeyDown={handleMenuKeyDown}
+        />
       )}
     </div>
   )
 }
 
-function renderMenuButton(
-  icon: ReactNode,
-  label: string,
-  shortcut: string | undefined,
-  onClick: () => void,
-) {
-  return (
-    <button
-      onMouseDown={(e) => e.preventDefault()}
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-      className="relative flex items-center w-full px-3 py-1.5 text-sm cursor-pointer active:bg-[var(--accent)] text-left rounded"
-      style={{ gap: 12, color: 'var(--foreground)' }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--muted)')}
-      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-    >
-      {icon}
-      <span>{label}</span>
-      {shortcut && <Kbd>{shortcut}</Kbd>}
-    </button>
-  )
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), Math.max(min, max))
+}
+
+function getMenuStyle(position: MenuViewportPosition | null): CSSProperties {
+  return {
+    left: position ? `${position.left}px` : '-9999px',
+    top: position ? `${position.top}px` : '-9999px',
+    minWidth: 180,
+  }
 }

--- a/app/flowix-web/features/editor/components/drag-context-menu/items.tsx
+++ b/app/flowix-web/features/editor/components/drag-context-menu/items.tsx
@@ -22,17 +22,17 @@ export type ListMenuItem = Extract<BlockMenuItem, { kind: 'list' }>
 const ICON_PROPS = { size: 16, weight: 'bold' as const }
 
 export const headingMenuItems: BlockMenuItem[] = [
-  { kind: 'heading', level: 1, icon: <TextHOneIcon {...ICON_PROPS} />, display: '#', shortcut: '⌘1' },
-  { kind: 'heading', level: 2, icon: <TextHTwoIcon {...ICON_PROPS} />, display: '##', shortcut: '⌘2' },
-  { kind: 'heading', level: 3, icon: <TextHThreeIcon {...ICON_PROPS} />, display: '###', shortcut: '⌘3' },
-  { kind: 'heading', level: 4, icon: <TextHFourIcon {...ICON_PROPS} />, display: '####', shortcut: '⌘4' },
-  { kind: 'paragraph', icon: <TextTIcon {...ICON_PROPS} />, display: '正文', shortcut: '⌘0' },
+  { kind: 'heading', level: 1, icon: <TextHOneIcon {...ICON_PROPS} />, display: '#', shortcut: 'Mod+1' },
+  { kind: 'heading', level: 2, icon: <TextHTwoIcon {...ICON_PROPS} />, display: '##', shortcut: 'Mod+2' },
+  { kind: 'heading', level: 3, icon: <TextHThreeIcon {...ICON_PROPS} />, display: '###', shortcut: 'Mod+3' },
+  { kind: 'heading', level: 4, icon: <TextHFourIcon {...ICON_PROPS} />, display: '####', shortcut: 'Mod+4' },
+  { kind: 'paragraph', icon: <TextTIcon {...ICON_PROPS} />, display: '正文', shortcut: 'Mod+0' },
 ]
 
 export const listMenuItems: ListMenuItem[] = [
   // 快捷键与 actions.ts 里的 defaultBinding 保持一致: Mod+Alt+8/7/9
   // (不是 Notion/Tiptap 默认的 Mod+Shift, 后者会与 Tiptap 内置 keymap 双 toggle 抵消)。
-  { kind: 'list', listType: 'bulletList', icon: <ListBulletsIcon {...ICON_PROPS} />, display: '无序列表', shortcut: '⌘⌥8' },
-  { kind: 'list', listType: 'orderedList', icon: <ListNumbersIcon {...ICON_PROPS} />, display: '有序列表', shortcut: '⌘⌥7' },
-  { kind: 'list', listType: 'taskList', icon: <CheckSquareIcon {...ICON_PROPS} />, display: '待办列表', shortcut: '⌘⌥9' },
+  { kind: 'list', listType: 'bulletList', icon: <ListBulletsIcon {...ICON_PROPS} />, display: '无序列表', shortcut: 'Mod+Alt+8' },
+  { kind: 'list', listType: 'orderedList', icon: <ListNumbersIcon {...ICON_PROPS} />, display: '有序列表', shortcut: 'Mod+Alt+7' },
+  { kind: 'list', listType: 'taskList', icon: <CheckSquareIcon {...ICON_PROPS} />, display: '待办列表', shortcut: 'Mod+Alt+9' },
 ]

--- a/app/flowix-web/features/editor/components/drag-context-menu/positioning.ts
+++ b/app/flowix-web/features/editor/components/drag-context-menu/positioning.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/core'
-import { getCurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
+import { getCurrentBlockInfo, type CurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
 import { getYOffset } from '@features/editor/components/drag-context-menu/style'
 
 /**
@@ -15,6 +15,7 @@ export interface HandlePosition {
   visible: true
   x: number
   y: number
+  blockInfo: CurrentBlockInfo
 }
 
 export interface HandleHidden {
@@ -22,11 +23,11 @@ export interface HandleHidden {
 }
 
 // Visible block ancestor selector. The handle positions itself on the
-// outermost "block" the user reads as a unit (the whole <ul>/<ol> for a
-// listItem cursor, the <td> for a tableCell, the <p> for a paragraph).
+// outermost "block" the user reads as a unit (the <ul>/<ol> for a list,
+// the <table> for a table, the <p> for a paragraph).
 // `.ProseMirror-node` is the catch-all for node-view wrappers.
 const BLOCK_SELECTOR =
-  'p, h1, h2, h3, h4, h5, h6, li, td, th, blockquote, pre, .ProseMirror-node'
+  'p, h1, h2, h3, h4, h5, h6, ul, ol, table, .tableWrapper, blockquote, pre, .ProseMirror-node'
 
 const HANDLE_X_OFFSET = 18
 
@@ -43,18 +44,20 @@ export function computeHandlePosition(
   editor: Editor,
   fontSize: number,
   lineHeight: number,
+  requireFocus = true,
 ): HandlePosition | HandleHidden | null {
   const view = editor.view
-  if (!view?.hasFocus()) return null
+  if (!view || (requireFocus && !view.hasFocus())) return null
 
   const editorDom = view.dom as HTMLElement
   const editorContent = editorDom.closest('.editor-content') as HTMLElement | null
   const info = getCurrentBlockInfo(editor)
   if (!info || !editorContent) return null
 
-  // Anchor the handle on the visible block ancestor (e.g. the
-  // <ul>/<ol> for a listItem, the <td> for a tableCell).
-  const domNode = info.dom.closest?.(BLOCK_SELECTOR) as HTMLElement | null
+  // Anchor the handle on the visible block element. Table node DOM may be the
+  // table itself or Tiptap's `.tableWrapper`; list node DOM is the rendered
+  // <ul>/<ol>. Resolve these before falling back to generic block ancestors.
+  const domNode = getVisibleBlockElement(info)
   if (!domNode) return null
 
   const proseMirrorRect = view.dom.getBoundingClientRect()
@@ -68,5 +71,19 @@ export function computeHandlePosition(
   const x = (proseMirrorRect.left - contentRect.left) + HANDLE_X_OFFSET
   const y = nodeRect.top - proseMirrorRect.top + getYOffset(info, fontSize, lineHeight)
 
-  return { visible: true, x, y }
+  return { visible: true, x, y, blockInfo: info }
+}
+
+function getVisibleBlockElement(info: CurrentBlockInfo): HTMLElement | null {
+  if (info.typeName === 'table') {
+    if (info.dom.matches('table, .tableWrapper')) return info.dom
+    const table = info.dom.querySelector('table')
+    if (table instanceof HTMLElement) return table
+  }
+  if (info.typeName === 'bulletList' || info.typeName === 'orderedList' || info.typeName === 'taskList') {
+    if (info.dom.matches('ul, ol')) return info.dom
+    const list = info.dom.querySelector('ul, ol')
+    if (list instanceof HTMLElement) return list
+  }
+  return info.dom.closest?.(BLOCK_SELECTOR) as HTMLElement | null
 }

--- a/app/flowix-web/features/editor/components/drag-context-menu/use-drag-handle-position.ts
+++ b/app/flowix-web/features/editor/components/drag-context-menu/use-drag-handle-position.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import type { Editor } from '@tiptap/core'
+import type { CurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
+import { computeHandlePosition } from '@features/editor/components/drag-context-menu/positioning'
+
+interface DragHandlePositionState {
+  visible: boolean
+  x: number
+  y: number
+  blockInfo: CurrentBlockInfo | null
+}
+
+const HIDDEN_STATE: DragHandlePositionState = {
+  visible: false,
+  x: 0,
+  y: 0,
+  blockInfo: null,
+}
+
+function isSameBlock(a: CurrentBlockInfo | null, b: CurrentBlockInfo | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.pos === b.pos && a.typeName === b.typeName && a.attrs.level === b.attrs.level
+}
+
+function shouldUpdateState(prev: DragHandlePositionState, next: DragHandlePositionState): boolean {
+  return (
+    prev.visible !== next.visible ||
+    prev.x !== next.x ||
+    prev.y !== next.y ||
+    !isSameBlock(prev.blockInfo, next.blockInfo)
+  )
+}
+
+export function useDragHandlePosition(
+  editor: Editor,
+  fontSize: number,
+  lineHeight: number,
+  ignoreBlurRef?: RefObject<boolean>,
+  keepVisibleRef?: RefObject<boolean>,
+): DragHandlePositionState {
+  const [state, setState] = useState<DragHandlePositionState>(HIDDEN_STATE)
+  const frameRef = useRef<number | null>(null)
+  const trailingResizeRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!editor?.view?.dom) return
+
+    let mounted = true
+
+    const commitState = (next: DragHandlePositionState) => {
+      if (!mounted) return
+      setState((prev) => shouldUpdateState(prev, next) ? next : prev)
+    }
+
+    const updateDragHandle = () => {
+      if (!mounted) return
+      const pos = computeHandlePosition(editor, fontSize, lineHeight, !keepVisibleRef?.current)
+      if (!pos || !pos.visible) {
+        commitState(HIDDEN_STATE)
+        return
+      }
+      commitState({
+        visible: true,
+        x: pos.x,
+        y: pos.y,
+        blockInfo: pos.blockInfo,
+      })
+    }
+
+    const scheduleUpdate = () => {
+      if (frameRef.current != null) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null
+        updateDragHandle()
+      })
+    }
+
+    const scheduleTrailingResizeUpdate = () => {
+      if (trailingResizeRef.current != null) {
+        window.clearTimeout(trailingResizeRef.current)
+      }
+      trailingResizeRef.current = window.setTimeout(() => {
+        trailingResizeRef.current = null
+        scheduleUpdate()
+      }, 80)
+    }
+
+    const editorDom = editor.view.dom as HTMLElement
+    const scrollContainer = editorDom.closest('.markdown-editor') as HTMLElement | null
+    const scrollTarget = scrollContainer || editorDom
+    const resizeTarget = scrollContainer || editorDom
+
+    const handleBlur = () => {
+      if (keepVisibleRef?.current) return
+      if (ignoreBlurRef?.current) return
+      commitState(HIDDEN_STATE)
+    }
+    const handleResize = () => {
+      scheduleUpdate()
+      scheduleTrailingResizeUpdate()
+    }
+
+    editor.on('selectionUpdate', updateDragHandle)
+    editor.on('focus', updateDragHandle)
+    editor.on('blur', handleBlur)
+    scrollTarget.addEventListener('scroll', scheduleUpdate, { passive: true })
+
+    const resizeObserver = new ResizeObserver(handleResize)
+    resizeObserver.observe(resizeTarget)
+    updateDragHandle()
+
+    return () => {
+      mounted = false
+      if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+      if (trailingResizeRef.current != null) window.clearTimeout(trailingResizeRef.current)
+      frameRef.current = null
+      trailingResizeRef.current = null
+      editor.off('selectionUpdate', updateDragHandle)
+      editor.off('focus', updateDragHandle)
+      editor.off('blur', handleBlur)
+      scrollTarget.removeEventListener('scroll', scheduleUpdate)
+      resizeObserver.disconnect()
+    }
+  }, [editor, fontSize, lineHeight, ignoreBlurRef, keepVisibleRef])
+
+  return state
+}

--- a/app/flowix-web/features/editor/components/slash-menu-dropdown.tsx
+++ b/app/flowix-web/features/editor/components/slash-menu-dropdown.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useLayoutEffect, useRef, type MouseEvent } from 'react';
 import {
   CheckSquareIcon,
+  CodeIcon,
   ImageSquareIcon,
   ListBulletsIcon,
   ListNumbersIcon,
@@ -16,6 +17,7 @@ import { ShortcutKbd } from '@shared/ui/shortcut-kbd';
 
 export type SlashMenuItemId =
   | 'blockquote'
+  | 'code-block'
   | 'table'
   | 'horizontal-rule'
   | 'bullet-list'
@@ -74,6 +76,13 @@ export const SLASH_MENU_ITEMS: SlashMenuItem[] = [
     label: '引用',
     keywords: ['quote', 'blockquote', 'yinyong', '引用'],
     icon: QuotesIcon,
+    section: '添加块',
+  },
+  {
+    id: 'code-block',
+    label: '代码块',
+    keywords: ['code', 'block', 'codeblock', 'daimakuai', '代码', 'kuai'],
+    icon: CodeIcon,
     section: '添加块',
   },
   {

--- a/app/flowix-web/features/editor/extensions/agent-thread-card.tsx
+++ b/app/flowix-web/features/editor/extensions/agent-thread-card.tsx
@@ -21,6 +21,8 @@ declare module '@tiptap/core' {
       insertAgentThreadCard: (options?: {
         roleKey?: AgentRoleKey;
         replaceRange?: { from: number; to: number };
+        initialPrompt?: string;
+        autoSubmit?: boolean;
       }) => ReturnType;
     };
   }
@@ -695,6 +697,7 @@ actions.append(
     this.subscribe();
     this.updateMultiLineState();
     this.scheduleLoadThreadCache();
+    this.runInitialPromptIfNeeded();
   }
 
   private get threadId(): string | null {
@@ -714,6 +717,29 @@ actions.append(
 
   private get collapsed(): boolean {
     return !!this.node.attrs.collapsed;
+  }
+
+  private consumeInitialPrompt(): string | null {
+    const initialPrompt = typeof this.node.attrs.initialPrompt === 'string'
+      ? this.node.attrs.initialPrompt.trim()
+      : '';
+    if (!initialPrompt || !this.node.attrs.autoSubmit) return null;
+
+    this.updateAttrs({ initialPrompt: null, autoSubmit: false });
+    return initialPrompt;
+  }
+
+  private runInitialPromptIfNeeded(): void {
+    const initialPrompt = this.consumeInitialPrompt();
+    if (!initialPrompt) return;
+
+    this.input.value = initialPrompt;
+    this.updateMultiLineState();
+
+    requestAnimationFrame(() => {
+      if (this.isDestroyed) return;
+      void this.submit();
+    });
   }
 
   private subscribe(): void {
@@ -1395,6 +1421,8 @@ export const AgentThreadCard = Node.create({
       title: { default: DEFAULT_TITLE },
       roleKey: { default: DEFAULT_AGENT_ROLE_KEY },
       collapsed: { default: false },
+      initialPrompt: { default: null },
+      autoSubmit: { default: false },
     };
   },
 
@@ -1482,6 +1510,8 @@ export const AgentThreadCard = Node.create({
             title: DEFAULT_TITLE,
             roleKey,
             collapsed: false,
+            initialPrompt: options?.initialPrompt ?? null,
+            autoSubmit: !!options?.autoSubmit,
           });
           const from = options?.replaceRange?.from ?? state.selection.from;
           const to = options?.replaceRange?.to ?? from;

--- a/app/flowix-web/features/editor/extensions/attachment-link/nodes/view-file.ts
+++ b/app/flowix-web/features/editor/extensions/attachment-link/nodes/view-file.ts
@@ -105,20 +105,25 @@ class FileView implements ProseMirrorNodeView {
         card.appendChild(icon);
         card.appendChild(filenameSpan);
 
-        // 节点首部 caret 占位:
-        //  inline atom node 位于段落行首时, 浏览器把 caret 贴到
-        //  NodeView 第一个可定位点; 此前该点是 icon, caret 视觉上
-        //  "穿入图标". 改为在 wrapper 内、card 之前塞一个零宽空格
-        //  文本节点, caret 自然落在这个文本节点上, 与图标不再重叠.
+        // 节点首/尾部 caret 占位:
+        //  inline atom node 位于段落行首/行尾时, 浏览器把 caret 贴到
+        //  NodeView 第一个/最后一个可定位点; 此前该点是 icon / 末尾文字,
+        //  caret 视觉上 "穿入图标" 或 "贴卡片右边缘". 改为在 wrapper 内、
+        //  card 前后各塞一个零宽空格文本节点, caret 自然落在文本节点上,
+        //  与卡片边缘不再重叠.
         //  - 必须是 TextNode (createTextNode), <span> 不行——
-        //    span 的边缘问题与 icon 相同, caret 仍会贴其左边缘.
+        //    span 的边缘问题与 icon 相同, caret 仍会贴其左/右边缘.
         //  - 零宽空格 U+200B 不可见、不占字宽, 视觉上无副作用.
         //  - wrapper 整体 contentEditable=false + user-select:none
         //    (见 editor-attachment-link.css), 用户无法选中或编辑.
         //  - ignoreMutation 返回 true, PM 不会把这段 DOM 视为内容变更.
-        const caretSpacer = document.createTextNode('​');
-        wrapper.appendChild(caretSpacer);
+        //  - 前后对称两个 spacer: 保证从左侧进卡片 (← / Home) 与从右侧
+        //    出卡片 (→ / End) 时 caret 着陆点一致, 与 note-reference 同源.
+        const caretSpacerLeading = document.createTextNode('​');
+        const caretSpacerTrailing = document.createTextNode('​');
+        wrapper.appendChild(caretSpacerLeading);
         wrapper.appendChild(card);
+        wrapper.appendChild(caretSpacerTrailing);
 
         wrapper.addEventListener('mousedown', (e) => {
             if (e.button !== 0) return;
@@ -279,12 +284,15 @@ export const FileAttachment = Node.create({
             : url ?? '';
         // DOM 形状与 createCard (NodeView) 对齐:
         //   wrapper [.editor-file-attachment]
-        //     zero-width 文本 (caret spacer, 与 NodeView 一致)
+        //     leading zero-width 文本 (caret spacer, 与 NodeView 一致)
         //     __card [.editor-file-attachment__card]
         //       icon (RiAttachment2 SVG, currentColor)
         //       __name (附件名)
+        //     trailing zero-width 文本 (caret spacer, 与 NodeView 一致)
         // 嵌套 __card 才能让 CSS 的 .is-selected .editor-file-attachment__card
         // 选中背景匹配 (避免 round-trip 后选中背景失效).
+        // 前后对称两个 spacer, 与 createCard 的 NodeView 保持一致, 保证
+        // 文档从 HTML 解析回来时 caret 落点与编辑器实时渲染一致.
         return [
             'span',
             mergeAttributes(
@@ -320,6 +328,7 @@ export const FileAttachment = Node.create({
                 ],
                 ['span', { class: 'editor-file-attachment__name' }, name ?? ''],
             ],
+            '​',
         ];
     },
 

--- a/app/flowix-web/features/editor/extensions/block-drag.ts
+++ b/app/flowix-web/features/editor/extensions/block-drag.ts
@@ -1,0 +1,216 @@
+import type { Editor } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from 'prosemirror-state'
+import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view'
+import { getCurrentBlockInfo, type CurrentBlockInfo } from '@features/editor/components/drag-context-menu/block-info'
+
+export const BLOCK_DRAG_MIME = 'application/x-flowix-block-drag'
+
+interface DraggedBlockRange {
+  from: number
+  to: number
+  parentStart: number
+  parentTypeName: string
+}
+
+interface BlockDragState extends DraggedBlockRange {
+  dropPos: number | null
+}
+
+export const blockDragPluginKey = new PluginKey<BlockDragState | null>('blockDrag')
+
+export const BlockDragExtension = Extension.create({
+  name: 'blockDrag',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<BlockDragState | null>({
+        key: blockDragPluginKey,
+        state: {
+          init: () => null,
+          apply(tr, value) {
+            const meta = tr.getMeta(blockDragPluginKey)
+            if (meta !== undefined) return meta
+            if (!value || !tr.docChanged) return value
+            const from = tr.mapping.map(value.from, -1)
+            const to = tr.mapping.map(value.to, 1)
+            if (from >= to) return null
+            const dropPos = value.dropPos == null ? null : tr.mapping.map(value.dropPos, -1)
+            return { ...value, from, to, dropPos }
+          },
+        },
+        props: {
+          decorations(state) {
+            const drag = blockDragPluginKey.getState(state)
+            if (drag?.dropPos == null) return null
+            return DecorationSet.create(state.doc, [
+              Decoration.widget(drag.dropPos, () => {
+                const marker = document.createElement('div')
+                marker.className = 'flowix-block-drop-indicator'
+                marker.contentEditable = 'false'
+                return marker
+              }, { side: -1 }),
+            ])
+          },
+        },
+      }),
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            dragleave(view, event) {
+              const drag = blockDragPluginKey.getState(view.state)
+              if (!drag) return false
+              if (event.relatedTarget instanceof Node && view.dom.contains(event.relatedTarget)) {
+                return false
+              }
+              view.dispatch(view.state.tr.setMeta(blockDragPluginKey, { ...drag, dropPos: null }))
+              return false
+            },
+          },
+        },
+      }),
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            dragover(view, event) {
+              const drag = blockDragPluginKey.getState(view.state)
+              if (!drag) return false
+              event.preventDefault()
+              const dropPos = findInsertPos(view, drag, event.clientX, event.clientY)
+              const validDropPos = dropPos != null && isValidDropPos(view, drag, dropPos)
+                ? dropPos
+                : null
+              if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = validDropPos == null ? 'none' : 'move'
+              }
+              if (drag.dropPos !== validDropPos) {
+                view.dispatch(view.state.tr.setMeta(blockDragPluginKey, { ...drag, dropPos: validDropPos }))
+              }
+              return true
+            },
+            drop(view, event) {
+              if (!hasActiveBlockDrag(view)) return false
+              event.preventDefault()
+              moveDraggedBlock(view, event.clientX, event.clientY)
+              return true
+            },
+          },
+        },
+      }),
+    ]
+  },
+})
+
+export function startBlockDrag(editor: Editor, info?: CurrentBlockInfo | null): boolean {
+  const block = info ?? getCurrentBlockInfo(editor)
+  if (!block) return false
+
+  const $pos = editor.state.doc.resolve(block.pos)
+  const parent = $pos.parent
+  const range: BlockDragState = {
+    from: block.pos,
+    to: block.pos + block.nodeSize,
+    parentStart: $pos.start($pos.depth),
+    parentTypeName: parent.type.name,
+    dropPos: null,
+  }
+
+  editor.view.dispatch(editor.state.tr.setMeta(blockDragPluginKey, range))
+  return true
+}
+
+export function endBlockDrag(editor: Editor): void {
+  editor.view.dispatch(editor.state.tr.setMeta(blockDragPluginKey, null))
+}
+
+function hasActiveBlockDrag(view: EditorView): boolean {
+  return blockDragPluginKey.getState(view.state) != null
+}
+
+function moveDraggedBlock(view: EditorView, clientX: number, clientY: number): boolean {
+  const drag = blockDragPluginKey.getState(view.state)
+  if (!drag) return false
+
+  const insertPos = drag.dropPos ?? findInsertPos(view, drag, clientX, clientY)
+  if (insertPos == null || !isValidDropPos(view, drag, insertPos)) {
+    view.dispatch(view.state.tr.setMeta(blockDragPluginKey, null))
+    return false
+  }
+
+  const { state } = view
+  const slice = state.doc.slice(drag.from, drag.to)
+  const blockSize = drag.to - drag.from
+  const mappedInsertPos = insertPos > drag.from ? insertPos - blockSize : insertPos
+
+  if (mappedInsertPos === drag.from) {
+    view.dispatch(state.tr.setMeta(blockDragPluginKey, null))
+    return false
+  }
+
+  try {
+    const tr = state.tr
+      .delete(drag.from, drag.to)
+      .insert(mappedInsertPos, slice.content)
+      .setMeta(blockDragPluginKey, null)
+    view.dispatch(tr.scrollIntoView())
+    return true
+  } catch {
+    view.dispatch(state.tr.setMeta(blockDragPluginKey, null))
+    return false
+  }
+}
+
+function findInsertPos(
+  view: EditorView,
+  drag: DraggedBlockRange,
+  clientX: number,
+  clientY: number,
+): number | null {
+  const coords = view.posAtCoords({ left: clientX, top: clientY })
+  if (!coords) return null
+
+  const { doc } = view.state
+  const $pos = doc.resolve(coords.pos)
+  let parentDepth: number | null = null
+
+  for (let depth = $pos.depth; depth >= 0; depth--) {
+    const node = $pos.node(depth)
+    const start = depth === 0 ? 0 : $pos.start(depth)
+    if (node.type.name === drag.parentTypeName && start === drag.parentStart) {
+      parentDepth = depth
+      break
+    }
+  }
+
+  if (parentDepth == null || parentDepth + 1 > $pos.depth) return null
+
+  const childPos = $pos.before(parentDepth + 1)
+  const child = doc.nodeAt(childPos)
+  if (!child) return null
+
+  const dom = view.nodeDOM(childPos)
+  if (!(dom instanceof HTMLElement)) return childPos
+
+  const rect = dom.getBoundingClientRect()
+  return clientY > rect.top + rect.height / 2 ? childPos + child.nodeSize : childPos
+}
+
+function isValidDropPos(view: EditorView, drag: DraggedBlockRange, insertPos: number): boolean {
+  if (insertPos >= drag.from && insertPos <= drag.to) return false
+
+  const { doc } = view.state
+  if (insertPos < 0 || insertPos > doc.content.size) return false
+
+  try {
+    const $insert = doc.resolve(insertPos)
+    const sameParent =
+      $insert.parent.type.name === drag.parentTypeName &&
+      $insert.start($insert.depth) === drag.parentStart
+    if (!sameParent) return false
+
+    const slice = doc.slice(drag.from, drag.to)
+    return $insert.parent.canReplace($insert.index(), $insert.index(), slice.content)
+  } catch {
+    return false
+  }
+}

--- a/app/flowix-web/features/editor/extensions/codeblock-shiki/codeblock-shiki-view.ts
+++ b/app/flowix-web/features/editor/extensions/codeblock-shiki/codeblock-shiki-view.ts
@@ -12,6 +12,20 @@ type CodeBlockViewMode = 'preview' | 'code'
 
 const MERMAID_LANGUAGE = 'mermaid'
 
+// shiki 的 "无高亮" sentinel ── 'plaintext' 不是真实语言 (shiki
+// 的 bundledLanguagesInfo 不收录这个条目, langs/ 目录也没有
+// plaintext.mjs), 它只是占位标识, 让 shiki 跳过 grammar 加载。
+// codebase 在多处用它当默认值:
+//   - codeblock-shiki.ts 的 defaultLanguage (Tiptap 节点 attr 默认值)
+//   - shiki-decorations.ts / shiki-highlighter.ts 里 "language !== 'plaintext' 才加载 grammar" 的判断
+//
+// 因此 id → label 解析时, 'plaintext' 必须走专门分支, 不能依赖
+// bundled.find() ── 后者会 miss, 退回 id 自身, button 上就
+// 永远停在 'plaintext' (小写)。空 attr 同理 ── dropdown "Plain Text"
+// 项设置的就是空值, 也走这条分支, 跟 'plaintext' 渲染统一。
+const PLAIN_TEXT_ID = 'plaintext'
+const PLAIN_TEXT_LABEL = 'Plain Text'
+
 const MERMAID_PREVIEW_ICON = `<svg class="code-block-mode-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
   <path d="M2 3h20"></path>
   <path d="M21 3v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V3"></path>
@@ -40,6 +54,19 @@ const ZOOM_OUT_ICON = '<svg class="code-block-fullscreen-icon" viewBox="0 0 256 
 
 const ZOOM_IN_ICON = '<svg class="code-block-fullscreen-icon" viewBox="0 0 256 256" aria-hidden="true" focusable="false"><path fill="currentColor" d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path></svg>'
 
+// 复制按钮图标 ── 默认态 (clipboard) 和成功态 (checkmark)。提到模块
+// 顶层做常量, 不再每次 click 时从 DOM 读 innerHTML 当「原始态」保存 ──
+// 那种保存方式在快速重复点击下会让第二次点击把 check icon 当成原态,
+// 后续 timer 全部还原成 check icon, 状态卡死。
+const COPY_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+</svg>`
+
+const COPY_CHECK_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <polyline points="20 6 9 17 4 12"></polyline>
+</svg>`
+
 type BundledLanguageInfo = {
   id: string
   name: string
@@ -55,11 +82,7 @@ function loadBundledLanguagesInfo(): Promise<readonly BundledLanguageInfo[]> {
 }
 
 export interface CodeBlockShikiViewOptions {
-  name: string
-  language: string | null
   theme: string
-  showLineNumbers?: boolean
-  highlightLines?: number[]
 }
 
 class CodeBlockShikiView implements NodeView {
@@ -67,7 +90,6 @@ class CodeBlockShikiView implements NodeView {
   contentDOM: HTMLElement
   view: NodeViewRendererProps['view']
   node: NodeViewRendererProps['node']
-  options: CodeBlockShikiViewOptions
   getPosFn: () => number | null | undefined
   private isDropdownOpen: boolean = false
   private boundOutsideClickHandler: ((e: Event) => void) | null = null
@@ -87,6 +109,12 @@ class CodeBlockShikiView implements NodeView {
   private actions: HTMLElement | null = null
   private fullscreenButton: HTMLButtonElement | null = null
   private viewMode: CodeBlockViewMode = 'code'
+  // 当前语言 id ── 与 button 显示的 label 解耦: button 走的是
+  // shiki metadata 里的 name (e.g. "TypeScript"), attr 存的是
+  // id (e.g. "typescript")。update() 路径需要靠这个字段 diff
+  // 外部变更, 不再读 button 文本 (label 跟 id 不对应, 没法
+  // 直接拿 button 文本跟新 id 比)。
+  private currentLanguageId: string = ''
   private renderVersion = 0
   private lastRenderedSource: string | null = null
   private boundThemeChangeHandler: ((e: Event) => void) | null = null
@@ -94,6 +122,10 @@ class CodeBlockShikiView implements NodeView {
   private boundHandleFullscreenKeydown: ((event: KeyboardEvent) => void) | null = null
   private isDestroyed = false
   private isFullscreen = false
+  // 复制成功态 reset timer ── 每次点击复制都重新调度, 旧的必须先
+  // clearTimeout, 否则快速重复点击会让多个 timer 串行触发, 后发的
+  // 把先发的还原给覆盖掉, 状态卡在 check icon 上不去。
+  private copyResetTimer: ReturnType<typeof setTimeout> | null = null
   // 全屏 overlay ── 独立的 DOM 树, 挂在 document.body 上, 跟原
   // code-block-wrapper 解耦, 避免与 wrapper 自身的预览态 / 折叠态
   // 互相影响。fullscreenContainer 是 overlay 的"定位参照物"
@@ -122,24 +154,22 @@ class CodeBlockShikiView implements NodeView {
     this.view = view
     this.node = node
     this.getPosFn = getPos
-    this.options = {
-      name: node.type.name,
-      showLineNumbers: node.attrs.showLineNumbers,
-      highlightLines: node.attrs.highlightLines,
-      language: node.attrs.language,
-      theme: node.attrs.theme
-    }
 
     this.dom = document.createElement('pre')
     this.contentDOM = document.createElement('code')
 
     this.createView()
     this.handleEvents()
+    // 异步把 button 上的原始 id (e.g. "typescript") 替换成 label
+    // (e.g. "TypeScript") ── createView 里先用 id 占位是必要的,
+    // 否则首帧 button 是空的; 后续 microtask 内覆盖, 闪一帧
+    // 用户基本无感。
+    void this.applyLanguageDisplay()
   }
 
   private createView() {
     this.dom.classList.add('code-block-wrapper')
-    this.dom.setAttribute('data-theme', this.options.theme || 'rose-pine-dawn')
+    this.dom.setAttribute('data-theme', this.node.attrs.theme || 'rose-pine-dawn')
 
     // Create header
     this.header = document.createElement('div')
@@ -159,7 +189,11 @@ class CodeBlockShikiView implements NodeView {
     this.languageBtn.classList.add('code-block-language-selector')
     this.languageBtn.type = 'button'
     this.languageBtn.tabIndex = -1
-    this.languageBtn.innerHTML = `<span class="code-block-language-label">${this.node.attrs.language || 'plaintext'}</span>
+    this.languageBtn.innerHTML = `<span class="code-block-language-label">${
+      !this.node.attrs.language || this.node.attrs.language === PLAIN_TEXT_ID
+        ? PLAIN_TEXT_LABEL
+        : this.node.attrs.language
+    }</span>
       <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="6 9 12 15 18 9"></polyline>
       </svg>`
@@ -170,10 +204,7 @@ class CodeBlockShikiView implements NodeView {
     this.copyBtn.type = 'button'
     this.copyBtn.tabIndex = -1
     this.copyBtn.title = 'Copy code'
-    this.copyBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-    </svg>`
+    this.copyBtn.innerHTML = COPY_ICON_SVG
 
     // Mermaid preview/code tabs
     this.modeTabs = document.createElement('div')
@@ -279,7 +310,10 @@ class CodeBlockShikiView implements NodeView {
     item.dataset.label = label.toLowerCase()
     item.dataset.value = value.toLowerCase()
     item.addEventListener('click', () => {
-      this.updateLanguage(value)
+      // 把构造时的 label 一并塞进去 ── updateLanguage 拿到同步 label
+      // 就直接写 button, 跳过 applyLanguageDisplay 的 microtask,
+      // 避免用户点完看到 "typescript" 闪一下再变 "TypeScript"。
+      this.updateLanguage(value, label)
       this.closeDropdown()
     })
     return item
@@ -352,8 +386,13 @@ class CodeBlockShikiView implements NodeView {
     if (this.isDestroyed) return
     list.replaceChildren()
 
-    // Auto detect option
-    list.appendChild(this.createLanguageDropdownItem('Auto Detect', ''))
+    // Plain text option ── dropdown 选项文案跟 button 状态描述
+    // 对齐: 空 attr 在两条路径 (sync click / async resolve) 都
+    // 显示 "Plain Text", 用户视角一个按钮一种文案。不用 "Auto Detect"
+    // 是因为 shiki 并没有自动检测能力, 选它只是清空 attr, "Plain Text"
+    // 更准确反映 shiki "无高亮" 的语义, 也跟 shiki metadata 里
+    // id="plaintext", name="Plain Text" 的命名一致。
+    list.appendChild(this.createLanguageDropdownItem('Plain Text', ''))
 
     // Language options
     const languages = bundledLanguagesInfo.map(lang => ({
@@ -432,7 +471,7 @@ class CodeBlockShikiView implements NodeView {
     this.boundOutsideClickHandler = null
   }
 
-  private updateLanguage(language: string) {
+  private updateLanguage(language: string, displayLabel?: string) {
     const { state, dispatch } = this.view
     const pos = this.getPos()
 
@@ -440,7 +479,17 @@ class CodeBlockShikiView implements NodeView {
 
     const tr = state.tr.setNodeAttribute(pos, 'language', language)
     dispatch(tr)
-    this.updateLanguageButton(language)
+    // dropdown click 路径 ── 构造 item 时 label 已传进来, 同步
+    // 塞给 button, 避免 async 解析造成一闪 "typescript" → "TypeScript"。
+    // 其他路径 (外部 update) 没有 label, 走 applyLanguageDisplay 异步
+    // 解析。两条路径都顺手更新 currentLanguageId, 让 update() 后续
+    // 不会再误判成"语言变了"重复刷新。
+    this.currentLanguageId = language
+    if (displayLabel) {
+      this.updateLanguageButton(displayLabel)
+    } else {
+      void this.applyLanguageDisplay()
+    }
     // 切到非 mermaid 语言时强制退出全屏 ── 避免全屏态挂着 mermaid
     // SVG 但节点本身已不再是 mermaid, view 渲染可能与全屏态不一致
     // (e.g. preview 表面被 display: none 隐藏, 全屏 CSS 仍 fixed 显示
@@ -452,10 +501,44 @@ class CodeBlockShikiView implements NodeView {
     this.syncMermaidView()
   }
 
-  private updateLanguageButton(language: string) {
+  // 把当前 attr.language 解析成人类可读 label 并写入 button ──
+  // 统一入口: 初始化 / 外部 update / fallback 路径都走这里。dropdown
+  // click 路径直接传 label 绕过, 避免 microtask 闪一下。
+  //
+  // 空 id (用户选了 dropdown 里的 "Plain Text" 项, 或 attr 初始为
+  // 空) 走 "Plain Text" 显示 ── dropdown 项跟 button 状态描述文案
+  // 对齐: 同一份数据两种视图都用 "Plain Text", 不再区分动作/状态
+  // 语义, 用户视角一个空 attr 只对应一个 label。
+  private async applyLanguageDisplay(): Promise<void> {
     if (!this.languageBtn) return
 
-    const label = language || 'plaintext'
+    const id = this.node.attrs.language || ''
+    this.currentLanguageId = id
+
+    let displayLabel: string
+    if (!id || id === PLAIN_TEXT_ID) {
+      // 专门处理 'plaintext' sentinel ── shiki bundledLanguagesInfo
+      // 不收录此条目 (它不是真实语言, 只是无高亮占位), lookup 必然
+      // miss 会让 button 永远停在 'plaintext' 小写态。空 attr 同理:
+      // dropdown "Plain Text" 项设的就是空值, 两条路径统一走 label。
+      displayLabel = PLAIN_TEXT_LABEL
+    } else {
+      try {
+        const bundled = await loadBundledLanguagesInfo()
+        if (this.isDestroyed) return
+        const match = bundled.find((lang) => lang.id === id)
+        displayLabel = match?.name ?? id
+      } catch {
+        // metadata 加载失败 ── 退回 id 自身 (跟旧行为一致), 不阻塞 UI。
+        displayLabel = id
+      }
+    }
+    this.updateLanguageButton(displayLabel)
+  }
+
+  private updateLanguageButton(label: string) {
+    if (!this.languageBtn) return
+
     const labelSpan = this.languageBtn.querySelector('.code-block-language-label')
     if (labelSpan) {
       labelSpan.textContent = label
@@ -1021,17 +1104,24 @@ private unmountFullscreenOverlay(): void {
   private showCopySuccess() {
     if (!this.copyBtn) return
 
-    const originalHTML = this.copyBtn.innerHTML
-    this.copyBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <polyline points="20 6 9 17 4 12"></polyline>
-    </svg>`
+    // 取消上一次点击的 reset timer ── 防止快速重复点击下多个 timer
+    // 串行触发, 后发 timer 把先发 timer 的还原给覆盖, 状态卡在
+    // check icon 上不去。直接复用「原态是 COPY_ICON_SVG」这一恒定
+    // 不变量, 不再从 DOM 读 innerHTML 存「原态」(后者在 check 态
+    // 下会捕获到错误值, 是 bug 的直接成因)。
+    if (this.copyResetTimer !== null) {
+      clearTimeout(this.copyResetTimer)
+      this.copyResetTimer = null
+    }
+
+    this.copyBtn.innerHTML = COPY_CHECK_ICON_SVG
     this.copyBtn.classList.add('copied')
 
-    setTimeout(() => {
-      if (this.copyBtn) {
-        this.copyBtn.innerHTML = originalHTML
-        this.copyBtn.classList.remove('copied')
-      }
+    this.copyResetTimer = setTimeout(() => {
+      this.copyResetTimer = null
+      if (!this.copyBtn) return
+      this.copyBtn.innerHTML = COPY_ICON_SVG
+      this.copyBtn.classList.remove('copied')
     }, 2000)
   }
 
@@ -1045,10 +1135,9 @@ private unmountFullscreenOverlay(): void {
     this.node = node
 
     // Update language button if changed externally
-    const newLang = node.attrs.language || ''
-    const currentLang = (this.languageBtn?.querySelector('.code-block-language-label') as HTMLElement)?.textContent || ''
-    if (newLang !== currentLang && newLang !== currentLang.replace(/^\s+|\s+$/g, '')) {
-      this.updateLanguageButton(newLang)
+    const newId = node.attrs.language || ''
+    if (newId !== this.currentLanguageId) {
+      void this.applyLanguageDisplay()
     }
 
     this.updateLanguageAttribute()
@@ -1074,6 +1163,14 @@ private unmountFullscreenOverlay(): void {
     if (this.boundThemeChangeHandler) {
       window.removeEventListener('app-theme-changed', this.boundThemeChangeHandler)
       this.boundThemeChangeHandler = null
+    }
+    // 取消 pending 的 copy reset timer ── 不清的话, NodeView 销毁
+    // (用户切走文档 / 关闭代码块) 后 timer 仍会触发, 对已 detach 的
+    // copyBtn 做 innerHTML 写入, 既无效也浪费 CPU, 还可能触发
+    // MutationObserver 噪声。
+    if (this.copyResetTimer !== null) {
+      clearTimeout(this.copyResetTimer)
+      this.copyResetTimer = null
     }
   }
 }

--- a/app/flowix-web/features/editor/extensions/codeblock-shiki/codeblock-shiki.ts
+++ b/app/flowix-web/features/editor/extensions/codeblock-shiki/codeblock-shiki.ts
@@ -70,6 +70,3 @@ export const CodeBlockShiki = CodeBlock.extend({
     ];
   },
 });
-
-// Export for external usage
-export { loadHighlighter, initHighlighter, loadLanguage, loadTheme } from '@features/editor/extensions/codeblock-shiki/shiki/shiki-highlighter';

--- a/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-decorations.ts
+++ b/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-decorations.ts
@@ -6,11 +6,60 @@ import { Decoration, DecorationSet } from '@tiptap/pm/view'
 
 import { getShiki } from '@features/editor/extensions/codeblock-shiki/shiki/shiki-highlighter'
 
+// ── 非 shiki 语言白名单 ──────────────────────────────────────────────
+//
+// 这些语言有自己的渲染管线 (NodeView), 不消费 shiki 的颜色 token ──
+// 跳过 tokenize + 颜色 inline decoration 构造, 纯省 work。当前只有
+// mermaid, 用 Set 数据驱动, 未来加 plantuml / vega-lite 等同族语言
+// 直接扩 Set 即可, 不需要分散改条件分支。
+const NON_SHIKI_LANGUAGES = new Set(['mermaid'])
+
 interface DecorationsOptions {
   doc: ProseMirrorNode
   name: string
   defaultTheme: BundledTheme
   defaultLanguage: BundledLanguage | 'plaintext' | null | undefined
+}
+
+// ── --shiki-theme CSS var 缓存 ────────────────────────────────────
+//
+// 该 var 由 useApplyTheme 在 app 主题切换时改写, 编辑过程中静态。
+// 旧实现每次 getDecorations() 都直接 getComputedStyle(documentElement),
+// 而该调用在存在 pending layout 的场景会强制同步 reflow ──
+//
+//   keystroke → transaction → apply() → getDecorations() → getComputedStyle
+//   ────────────────── 同一调用栈, reflow 阻断后续代码 ──────────────────
+//
+// 1000 行代码块连续输入时, reflow 跟 tokenize 串联叠加, 主线程被
+// 长时间占用。缓存读取结果, 把读路径退化成一个普通变量访问, 消
+// 除 reflow。
+//
+// 失效时机 ── 由 shiki-plugin.ts 在 view() 挂载时挂 per-editor
+// 'app-theme-changed' 监听器, 切主题时同步 invalidate + dispatch
+// forceDecoration 触发 apply 重算。本模块自身不挂监听器 ── 缓存
+// 与失效职责分离: 本文件管「读 + 缓存 + 暴露失效接口」, plugin
+// 决定「何时失效」(只有 plugin 持有 editorView 引用, 才能在失
+// 效后强制刷新装饰)。
+let cachedCssTheme: string | null | undefined = undefined
+
+function readCssTheme(): string {
+  if (cachedCssTheme !== undefined) return cachedCssTheme ?? ''
+  if (typeof document === 'undefined') {
+    cachedCssTheme = null
+    return ''
+  }
+  cachedCssTheme = getComputedStyle(document.documentElement)
+    .getPropertyValue('--shiki-theme')
+    .trim()
+  return cachedCssTheme ?? ''
+}
+
+/** 失效缓存 ── 由 shiki-plugin 在收到 app-theme-changed 时调用,
+ *  并伴随一次 shikiPluginForceDecoration dispatch 强制刷新装饰。
+ *  Export 是因为 plugin 是同模块的兄弟文件, 需要 import 这个
+ *  失效函数。 */
+export function invalidateShikiThemeCache() {
+  cachedCssTheme = undefined
 }
 
 export function getDecorations({
@@ -24,10 +73,20 @@ export function getDecorations({
   const codeBlocks = findChildren(doc, node => node.type.name === name)
 
   codeBlocks.forEach((block) => {
+    // Mermaid 等非 shiki 语言走 NodeView 自己的渲染管线, 不消费
+    // shiki 的颜色 token ── 早 return 跳过 tokenize + 颜色 inline
+    // decoration 构造, 纯省 work。
+    if (NON_SHIKI_LANGUAGES.has((block.node.attrs.language || '').toLowerCase())) return
+
     const highlighter = getShiki()
     if (!highlighter) return
 
     const highlightLines = new Set<string>(block.node.attrs.highlightLines || [])
+    // 行号显示开关 ── 节点未声明 showLineNumbers 时 (当前 @tiptap/
+    // extension-code-block 默认不提供此 attr), 视为 true 保持
+    // 现状; 显式 false 时跳过 widget 创建, 让 1000 行块少 1000
+    // 个 widget DOM 节点 + 1000 次 cloneNode, 直接减半。
+    const showLineNumbers = block.node.attrs.showLineNumbers !== false
     let language = block.node.attrs.language || defaultLanguage
 
     if (!highlighter.getLoadedLanguages().includes(language)) {
@@ -38,9 +97,8 @@ export function getDecorations({
     // Theme resolution: CSS var (app theme) > node attr (per-block override) > hardcoded default.
     // Reading --shiki-theme from :root lets useApplyTheme drive code-block colors;
     // node.attrs.theme remains in the schema for forward-compat (future per-block picker).
-    const cssTheme = typeof document !== 'undefined'
-      ? getComputedStyle(document.documentElement).getPropertyValue('--shiki-theme').trim()
-      : ''
+    // 读路径走 readCssTheme() 缓存, 避免每个 keystroke 触发 getComputedStyle 强制 reflow。
+    const cssTheme = readCssTheme()
     if (cssTheme) theme = cssTheme as BundledTheme
     const themeToApply = highlighter.getLoadedThemes().includes(theme)
       ? theme
@@ -53,25 +111,42 @@ export function getDecorations({
 
     let from = block.pos + 1
 
-    const baseSpan = document.createElement('span')
-    baseSpan.innerText = '​'
-
     lines.forEach((lineTokens, index) => {
       const lineIndex = String(index + 1)
-      const span = baseSpan.cloneNode(true) as HTMLElement
-      span.classList.add('line-number')
-      span.setAttribute('line', lineIndex)
+      const highlighted = highlightLines.has(lineIndex)
 
-      if (highlightLines.has(lineIndex)) span.classList.add('highlighted')
+      // 行号 widget ── 用 spec.key 让 ProseMirror 跨 getDecorations()
+      // 调用复用 DOM, 避免每帧重建 1000 个 widget 节点。key 由「行
+      // 文本 + highlight 状态」组成 ── 未编辑的行 key 稳定, ProseMirror
+      // 走 placeWidget 的「matchesWidget」分支直接 move DOM, 不调
+      // factory, 不创建新 span; 只有被编辑的行 (lineText 变化)
+      // 或 highlight 状态变化的行才触发 unmount+mount。
+      //
+      // 1000 行块连续输入时从「每帧 1000 unmount+mount」降到「每
+      // 帧 1 次 (被编辑的行) + 999 次 DOM move」。
+      if (showLineNumbers && typeof document !== 'undefined') {
+        const lineText = lineTokens.map(t => t.content).join('')
+        const widgetKey = `${lineText}|${highlighted ? 1 : 0}`
 
-      const decoration = Decoration.widget(from, () => span, {
-        side: -1,
-        ignoreSelection: true,
-        destroy() {
-          span.remove()
-        }
-      })
-      decorations.push(decoration)
+        decorations.push(Decoration.widget(
+          from,
+          () => {
+            const span = document.createElement('span')
+            span.classList.add('line-number')
+            span.setAttribute('line', lineIndex)
+            if (highlighted) span.classList.add('highlighted')
+            return span
+          },
+          {
+            key: widgetKey,
+            side: -1,
+            ignoreSelection: true,
+            // 通用 destroy ── 接收 ProseMirror 挂载的实际 DOM, 不
+            // 闭包捕获 span (避免每帧保留旧 span 引用, 让 GC 回收)。
+            destroy: (dom: Node) => { dom.parentNode?.removeChild(dom) },
+          }
+        ))
+      }
 
       for (const token of lineTokens) {
         const to = from + token.content.length

--- a/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-highlighter.ts
+++ b/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-highlighter.ts
@@ -16,14 +16,6 @@ function loadShikiModule() {
   return shikiModulePromise
 }
 
-export function resetHighlighter() {
-  highlighter = undefined
-  highlighterPromise = undefined
-  shikiModulePromise = undefined
-  loadingLanguages.clear()
-  loadingThemes.clear()
-}
-
 export function getShiki() {
   return highlighter
 }

--- a/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-plugin.ts
+++ b/app/flowix-web/features/editor/extensions/codeblock-shiki/shiki/shiki-plugin.ts
@@ -1,9 +1,11 @@
 import type { BundledLanguage, BundledTheme } from 'shiki'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import type { EditorView } from '@tiptap/pm/view'
+import type { Step } from '@tiptap/pm/transform'
 
-import { findChildren } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 
-import { getDecorations } from '@features/editor/extensions/codeblock-shiki/shiki/shiki-decorations'
+import { getDecorations, invalidateShikiThemeCache } from '@features/editor/extensions/codeblock-shiki/shiki/shiki-decorations'
 import { getShiki, initHighlighter } from '@features/editor/extensions/codeblock-shiki/shiki/shiki-highlighter'
 
 export interface PluginShikiOptions {
@@ -13,8 +15,81 @@ export interface PluginShikiOptions {
   preloadThemes?: BundledTheme[]
 }
 
+// ── apply() 辅助 ────────────────────────────────────────────────────
+//
+// 旧实现 [findChildren(doc) × 2 + oldNodes.some(node => range ⊆ step)]
+// 每次 transaction 走两遍完整 doc tree, 大文档 (数千节点) 时不算
+// 便宜 ── 100 keystrokes/秒 × 2000 visits = 200K visits/秒, 长期
+// 跑能吃掉可观的主线程预算。
+//
+// 新实现换成范围受限的遍历:
+//   - countCodeBlocks ── 只数数量, 不构造 children 数组 (省分配)
+//   - rangeContainsCodeBlock ── 用 nodesBetween(step.from, step.to)
+//     做范围相交检查, 典型 keystroke (range = 1 字符) 只走 1 个节点
+//     而非整篇 doc
+//
+// 顺带修正一个潜在正确性 bug: 旧检查 node.pos >= step.from &&
+// node.pos + nodeSize <= step.to 是「代码块 ⊆ step」语义 ── 只捕
+// 代码块删除; 代码块**内部编辑** (step 范围 < 代码块范围) 漏判,
+// 依赖 condition A (selection 在代码块内) 兜底。新检查是范围相交,
+// 两种语义同时覆盖, 即使将来有非交互式 transform 修改代码块内容
+// 也能正确触发 rAF。
+function countCodeBlocks(doc: ProseMirrorNode, typeName: string): number {
+  let count = 0
+  doc.descendants((node) => {
+    if (node.type.name === typeName) count++
+  })
+  return count
+}
+
+function rangeContainsCodeBlock(
+  doc: ProseMirrorNode,
+  from: number,
+  to: number,
+  typeName: string
+): boolean {
+  let found = false
+  doc.nodesBetween(from, to, (node) => {
+    if (node.type.name === typeName) {
+      found = true
+      return false
+    }
+  })
+  return found
+}
+
 export function proseMirrorPluginShiki(options: PluginShikiOptions) {
   const { name, defaultLanguage, defaultTheme, preloadThemes = [] } = options
+
+  // ── rAF 批处理 ────────────────────────────────────────────────
+  //
+  // 代码块内容变化的 keystroke 路径上, apply() 把昂贵的 getDecorations()
+  // (全量 tokenize + 重建 DecorationSet) 改成「延迟到下一帧」: 同
+  // 一帧内多个 keystroke 共用一次 tokenize, apply() 同步路径只返
+  // 回 mapped set (positions 跟着 transaction.mapping 走, colors
+  // 暂时 stale), 视觉延迟 < 16ms 不可察觉, 但避免单帧多次 tokenize
+  // 串联阻断主线程 ── 1000 行代码块连续输入时从「每键 50–200ms」变
+  // 成「每帧 1 次」。
+  //
+  // state 闭包 ── 每个 proseMirrorPluginShiki() 实例持有自己的
+  // currentView / pendingRaf, 多编辑器场景不互相干扰。
+  let currentView: EditorView | null = null
+  let pendingRaf: number | null = null
+
+  const flushRecompute = () => {
+    // 先清 pendingRaf 再 dispatch ── 万一 dispatch 触发嵌套调用
+    // scheduleRecompute, 状态机不会卡死。
+    pendingRaf = null
+    if (!currentView || currentView.isDestroyed) return
+    currentView.dispatch(
+      currentView.state.tr.setMeta('shikiPluginForceDecoration', true)
+    )
+  }
+
+  const scheduleRecompute = () => {
+    if (pendingRaf !== null) return
+    pendingRaf = requestAnimationFrame(flushRecompute)
+  }
 
   const shikiPlugin: Plugin = new Plugin({
     key: new PluginKey('codeBlockShiki'),
@@ -28,30 +103,60 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
         const oldNodeName = oldState.selection.$head.parent.type.name
         const newNodeName = newState.selection.$head.parent.type.name
 
-        const oldNodes = findChildren(oldState.doc, node => node.type.name === name)
-        const newNodes = findChildren(newState.doc, node => node.type.name === name)
+        // didChangeSomeCodeBlock 三条短路 OR, 任一为真即触发重算:
+        //   A: selection 跨代码块 (光标进/出) ── 不需要扫 doc
+        //   B: 代码块数量变化 (create / delete) ── countCodeBlocks 数
+        //   C: 至少一个 step 的范围相交代码块 (内容编辑 / 删除代码块) ──
+        //      rangeContainsCodeBlock 走范围受限的 nodesBetween
+        //
+        // 短路链按「成本递增」排列: A 单次字符串 includes 立即返回;
+        // B 即便跑也只是两次 descendants 计数, 不构造 children 数组
+        // (省分配); C 是最差情况 ── 此时一定有 step 触碰代码块, 范围
+        // 受限的 nodesBetween 仅遍历 step.from..to 范围而非整篇 doc。
+        // 多数 keystroke 在 A 即短路, 完全不进 doc 遍历路径。
+        let didChangeSomeCodeBlock = false
+        if (transaction.docChanged) {
+          if ([oldNodeName, newNodeName].includes(name)) {
+            didChangeSomeCodeBlock = true
+          } else if (countCodeBlocks(oldState.doc, name) !== countCodeBlocks(newState.doc, name)) {
+            didChangeSomeCodeBlock = true
+          } else {
+            didChangeSomeCodeBlock = transaction.steps.some((step: Step) => {
+              // Step 基类不暴露 from/to ── 运行时检查; 没有范围的
+              // step (e.g. DocAttrStep 改文档级属性) 直接跳过, 没有
+              // 位置意义上的代码块可以重叠。
+              const from = (step as { from?: number }).from
+              const to = (step as { to?: number }).to
+              if (from === undefined || to === undefined) return false
+              return rangeContainsCodeBlock(oldState.doc, from, to, name)
+            })
+          }
+        }
 
-        const didChangeSomeCodeBlock = transaction.docChanged && (
-          [oldNodeName, newNodeName].includes(name)
-          || newNodes.length !== oldNodes.length
-          || transaction.steps.some((step: any) => {
-            return (step.from !== undefined && step.to !== undefined
-              && oldNodes.some((node) => {
-                return (
-                  node.pos >= step.from
-                  && node.pos + node.node.nodeSize <= step.to
-                )
-              })
-            )
-          }))
-
-        if (transaction.getMeta('shikiPluginForceDecoration') || didChangeSomeCodeBlock) {
+        // 强制刷新路径 ── rAF 批处理触发 / highlighter 加载完成 /
+        // 外部显式调用 forceDecoration。同步执行, 不再 batched, 确
+        // 保调用方看到的 DecorationSet 立即反映 doc 状态。
+        if (transaction.getMeta('shikiPluginForceDecoration')) {
+          // 当前 transaction 已经把 doc 同步 tokenize 了一遍, 任何
+          // 之前因 keystroke 排上的 rAF 都已无意义 ── 取消掉, 避
+          // 免 rAF 触发后再跑一次相同输入的 getDecorations。
+          if (pendingRaf !== null) {
+            cancelAnimationFrame(pendingRaf)
+            pendingRaf = null
+          }
           return getDecorations({
             doc: transaction.doc,
             name,
             defaultLanguage,
             defaultTheme
           })
+        }
+
+        // 代码块内容变化 ── 排到下一帧统一重新计算, 当前 transaction
+        // 同步路径返回 mapped set 即可, 避免在 keystroke 回调栈里
+        // 跑全量 tokenize。
+        if (didChangeSomeCodeBlock) {
+          scheduleRecompute()
         }
 
         return decorationSet.map(transaction.mapping, transaction.doc)
@@ -67,6 +172,7 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
     // Lazy Shiki bootstrap: editor mount stays synchronous. Only documents that
     // actually contain code blocks import Shiki and load grammars/themes.
     view(editorView) {
+      currentView = editorView
       let cancelled = false
       let pending = false
       let needsRerun = false
@@ -74,7 +180,7 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
       let timeoutId: ReturnType<typeof setTimeout> | null = null
 
       const hasCodeBlocks = () => {
-        return findChildren(editorView.state.doc, node => node.type.name === name).length > 0
+        return countCodeBlocks(editorView.state.doc, name) > 0
       }
 
       const forceDecorations = () => {
@@ -83,6 +189,26 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
           editorView.state.tr.setMeta('shikiPluginForceDecoration', true)
         )
       }
+
+      // ── 主题切换响应 ──────────────────────────────────────────
+      // cssTheme 缓存 (shiki-decorations.ts) 把 getComputedStyle 从
+      // hot path 上拿掉, 但缓存只在下次 getDecorations 才会被消费,
+      // 而 getDecorations 只在 apply() 触发时跑 ── 用户切完主题
+      // 若不再输入, apply() 不跑, 装饰颜色就停留在旧值。
+      //
+      // 这里在 view() 挂 per-editor 监听器, 主题切换时:
+      //   1. invalidateShikiThemeCache() ── 清缓存, 下次 getDecorations
+      //      强制重新读 --shiki-theme (拿新主题)
+      //   2. forceDecorations() ── 派发 shikiPluginForceDecoration,
+      //      触发一次 apply() 同步重算, 把新主题应用到所有现有装饰
+      //
+      // destroy() 时同步 removeEventListener, 不留 zombie listener。
+      const handleThemeChange = () => {
+        if (cancelled) return
+        invalidateShikiThemeCache()
+        forceDecorations()
+      }
+      window.addEventListener('app-theme-changed', handleThemeChange)
 
       const loadForCurrentDoc = async () => {
         if (cancelled || pending || !hasCodeBlocks()) return
@@ -136,6 +262,7 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
         },
         destroy() {
           cancelled = true
+          window.removeEventListener('app-theme-changed', handleThemeChange)
           if (idleId !== null && 'cancelIdleCallback' in window) {
             window.cancelIdleCallback(idleId)
             idleId = null
@@ -144,6 +271,12 @@ export function proseMirrorPluginShiki(options: PluginShikiOptions) {
             globalThis.clearTimeout(timeoutId)
             timeoutId = null
           }
+          // 编辑器销毁时取消未触发的 rAF, 防止回调里访问已销毁的 view。
+          if (pendingRaf !== null) {
+            cancelAnimationFrame(pendingRaf)
+            pendingRaf = null
+          }
+          if (currentView === editorView) currentView = null
         }
       }
     }

--- a/app/flowix-web/features/editor/extensions/menu-pin.ts
+++ b/app/flowix-web/features/editor/extensions/menu-pin.ts
@@ -1,6 +1,13 @@
 import { Extension } from '@tiptap/core'
+import type { Node as PMNode } from 'prosemirror-model'
 import { Plugin, PluginKey } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
+
+export interface MenuPinState {
+  pos: number
+  typeName: string
+  nodeSize: number
+}
 
 /**
  * Editor-wide "menu pin" plugin.
@@ -18,52 +25,54 @@ import { Decoration, DecorationSet } from 'prosemirror-view'
  *
  * The position is set / cleared via the standard transaction metadata API:
  *
- *   editor.view.dispatch(editor.view.state.tr.setMeta(menuPinPluginKey, pos))
+ *   editor.view.dispatch(editor.view.state.tr.setMeta(menuPinPluginKey, pin))
  *   editor.view.dispatch(editor.view.state.tr.setMeta(menuPinPluginKey, null))
  *
- * The `pos` is the open-token position of the block (same value the
- * drag-context-menu uses for `deleteRange`). A range `pos .. pos + 1`
- * is the smallest valid range for a `Decoration.node`.
+ * The `pos` is the open-token position of the block. The plugin stores
+ * typeName/nodeSize with it so mapped positions are only kept when they
+ * still point to the same node. Decorations cover `pos .. pos + nodeSize`.
  */
-export const menuPinPluginKey = new PluginKey<number | null>('menuPin')
+export const menuPinPluginKey = new PluginKey<MenuPinState | null>('menuPin')
 
 export const MenuPinExtension = Extension.create({
   name: 'menuPin',
 
   addProseMirrorPlugins() {
     return [
-      new Plugin({
+      new Plugin<MenuPinState | null>({
         key: menuPinPluginKey,
         state: {
           init: () => null,
           apply(tr, value, _oldState, newState) {
             // External API takes priority (drag-context-menu dispatches
             // a transaction with setMeta to set or clear the pin).
-            const meta = tr.getMeta(menuPinPluginKey)
+            const meta = tr.getMeta(menuPinPluginKey) as MenuPinState | null | undefined
             if (meta !== undefined) return meta
 
-            // On doc changes, re-validate the pinned position. If the
-            // position is out of range or no longer points to a block,
-            // drop the pin (e.g. the user deleted the block via the menu).
+            // On doc changes, map the pinned position through the
+            // transaction before validating it. Without this, edits before
+            // the pinned block can leave the decoration attached to the
+            // wrong node.
             if (value != null && tr.docChanged) {
-              try {
-                const $pos = newState.doc.resolve(value)
-                if ($pos.depth < 1) return null
-                return value
-              } catch {
-                return null
-              }
+              const result = tr.mapping.mapResult(value.pos, -1)
+              if (result.deleted) return null
+              return validatePin(newState.doc, {
+                ...value,
+                pos: result.pos,
+              })
             }
 
-            return value
+            return validatePin(newState.doc, value)
           },
         },
         props: {
           decorations(state) {
-            const pos = menuPinPluginKey.getState(state)
-            if (pos == null) return null
+            const pin = validatePin(state.doc, menuPinPluginKey.getState(state) ?? null)
+            if (pin == null) return null
+            const node = state.doc.nodeAt(pin.pos)
+            if (!node) return null
             return DecorationSet.create(state.doc, [
-              Decoration.node(pos, pos + 1, { class: 'is-block-selected' }),
+              Decoration.node(pin.pos, pin.pos + node.nodeSize, { class: 'is-block-selected' }),
             ])
           },
         },
@@ -71,3 +80,19 @@ export const MenuPinExtension = Extension.create({
     ]
   },
 })
+
+function validatePin(doc: PMNode, pin: MenuPinState | null): MenuPinState | null {
+  if (pin == null) return null
+  if (pin.pos < 0 || pin.pos > doc.content.size) return null
+
+  try {
+    doc.resolve(pin.pos)
+    const node = doc.nodeAt(pin.pos)
+    if (!node) return null
+    if (node.type.name !== pin.typeName) return null
+    if (node.nodeSize !== pin.nodeSize) return null
+    return pin
+  } catch {
+    return null
+  }
+}

--- a/app/flowix-web/features/editor/extensions/slash-menu.tsx
+++ b/app/flowix-web/features/editor/extensions/slash-menu.tsx
@@ -285,6 +285,7 @@ function handleSelect(item: SlashMenuItem): void {
   // 这样不会出现 "/引用" 这种残留字符, 也避免选中既有段落内容被误改。
   const blockToggleById: Partial<Record<SlashMenuItem['id'], () => void>> = {
     'blockquote': () => editor.chain().focus().toggleBlockquote().run(),
+    'code-block': () => editor.chain().focus().toggleCodeBlock().run(),
     'bullet-list': () => editor.chain().focus().toggleBulletList().run(),
     'ordered-list': () => editor.chain().focus().toggleOrderedList().run(),
     'task-list': () => editor.chain().focus().toggleTaskList().run(),

--- a/app/flowix-web/features/editor/extensions/tab-agent-run.ts
+++ b/app/flowix-web/features/editor/extensions/tab-agent-run.ts
@@ -1,0 +1,94 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, TextSelection } from '@tiptap/pm/state';
+
+import { DEFAULT_AGENT_ROLE_KEY } from '@/lib/agent-roles';
+
+const DOUBLE_TAB_WINDOW_MS = 650;
+
+interface RunnableBlock {
+  from: number;
+  to: number;
+  prompt: string;
+}
+
+interface PendingTab extends RunnableBlock {
+  time: number;
+}
+
+function isSupportedTextBlock(typeName: string): boolean {
+  return typeName === 'paragraph' || typeName === 'heading';
+}
+
+function getRunnableBlock(selection: TextSelection): RunnableBlock | null {
+  if (!selection.empty) return null;
+
+  const { $from } = selection;
+  const blockDepth = $from.depth;
+  if (blockDepth !== 1) return null;
+
+  const block = $from.node(blockDepth);
+  if (!block.isTextblock || !isSupportedTextBlock(block.type.name)) return null;
+
+  const prompt = block.textContent.trim();
+  if (!prompt) return null;
+
+  return {
+    from: $from.before(blockDepth),
+    to: $from.after(blockDepth),
+    prompt,
+  };
+}
+
+function isPendingSecondTab(pendingTab: PendingTab | null, block: RunnableBlock, now: number): boolean {
+  return !!pendingTab
+    && pendingTab.from === block.from
+    && pendingTab.to === block.to
+    && pendingTab.prompt === block.prompt
+    && now - pendingTab.time <= DOUBLE_TAB_WINDOW_MS;
+}
+
+export const TabAgentRun = Extension.create({
+  name: 'tabAgentRun',
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    let pendingTab: { from: number; to: number; prompt: string; time: number } | null = null;
+
+    return [
+      new Plugin({
+        props: {
+          handleKeyDown(view, event) {
+            if (event.key !== 'Tab') return false;
+            if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return false;
+            if (event.isComposing || !editor.isEditable) return false;
+
+            const { selection } = view.state;
+            if (!(selection instanceof TextSelection)) return false;
+
+            const block = getRunnableBlock(selection);
+            if (!block) {
+              pendingTab = null;
+              return false;
+            }
+            const now = Date.now();
+
+            event.preventDefault();
+            if (!isPendingSecondTab(pendingTab, block, now)) {
+              pendingTab = { ...block, time: now };
+              return true;
+            }
+
+            pendingTab = null;
+            editor.chain().insertAgentThreadCard({
+              roleKey: DEFAULT_AGENT_ROLE_KEY,
+              replaceRange: { from: block.from, to: block.to },
+              initialPrompt: block.prompt,
+              autoSubmit: true,
+            }).run();
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/app/flowix-web/features/editor/extensions/table/table-bubble-menu.tsx
+++ b/app/flowix-web/features/editor/extensions/table/table-bubble-menu.tsx
@@ -227,6 +227,7 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
               editor.chain().focus().deleteRow().run();
             }}
             type="button"
+            className="destructive"
           >
             <RowsDeleteIcon size={18} />
           </button>
@@ -261,6 +262,7 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
               editor.chain().focus().deleteColumn().run();
             }}
             type="button"
+            className="destructive"
           >
             <ColumnsDeleteIcon size={18} />
           </button>
@@ -273,9 +275,9 @@ export function TableBubbleMenu({ editor }: TableBubbleMenuProps) {
               editor.chain().focus().deleteTable().run();
             }}
             type="button"
-            className="delete-table-btn"
+            className="destructive"
           >
-            <AgentTrashIcon size={18} />
+            <AgentTrashIcon size={16} />
           </button>
         </Tooltip>
       </div>

--- a/app/flowix-web/features/editor/extensions/table/table-edge-insert-plugin.ts
+++ b/app/flowix-web/features/editor/extensions/table/table-edge-insert-plugin.ts
@@ -13,8 +13,8 @@ interface EdgeTarget {
 }
 
 const tableEdgeInsertPluginKey = new PluginKey('tableEdgeInsert');
-const EDGE_BUTTON_SIZE = 14;
-const EDGE_GAP = 2;
+const EDGE_BUTTON_SIZE = 16;
+const EDGE_GAP = 4;
 
 function closestTableCell(target: EventTarget | null): HTMLTableCellElement | null {
   if (!(target instanceof Element)) return null;
@@ -26,6 +26,13 @@ function getEdgeTarget(view: EditorView, eventTarget: EventTarget | null): EdgeT
   const cell = closestTableCell(eventTarget);
   const table = cell?.closest('table');
   if (!cell || !(table instanceof HTMLTableElement)) return null;
+
+  // AgentThreadCard 是只读 NodeView (`contentEditable='false'`), 卡片内
+  // 的 markdown 表格用 `marked` 实时渲染, 不属于 ProseMirror 表格节点 ──
+  // 它的 cell 在 ProseMirror 文档里没有对应位置, 触发 addColumnAfter/
+  // addRowAfter 会出错, 按钮本身也会错位叠加在卡片边缘. 命中则当作
+  // "非编辑器表格" 直接忽略.
+  if (cell.closest('.agent-thread-card')) return null;
 
   const row = cell.parentElement;
   if (!(row instanceof HTMLTableRowElement)) return null;

--- a/app/flowix-web/features/editor/markdown-editor.tsx
+++ b/app/flowix-web/features/editor/markdown-editor.tsx
@@ -29,8 +29,10 @@ import { SearchAndReplace } from '@features/editor/extensions/search-replace';
 import { SearchReplacePanel } from '@features/editor/components/search-replace-panel';
 import Frontmatter from '@features/editor/extensions/frontmatter';
 import { MenuPinExtension } from '@features/editor/extensions/menu-pin';
+import { BlockDragExtension } from '@features/editor/extensions/block-drag';
 import { SlashMenu } from '@features/editor/extensions/slash-menu';
 import { AgentThreadCard } from '@features/editor/extensions/agent-thread-card';
+import { TabAgentRun } from '@features/editor/extensions/tab-agent-run';
 import { TablePlugin } from '@features/editor/extensions/table/table-plugin';
 
 interface MarkdownEditorProps {
@@ -419,8 +421,10 @@ export function MarkdownEditor({
         TagMention,
         AgentThreadCard,
         SlashMenu,
+        TabAgentRun,
         SearchAndReplace,
         MenuPinExtension,
+        BlockDragExtension,
       ],
       content: initialContent,
       contentType: 'markdown',

--- a/app/flowix-web/features/memo/components/memo-card-actions.tsx
+++ b/app/flowix-web/features/memo/components/memo-card-actions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PushPin, TrashIcon } from "@phosphor-icons/react";
+import { PushPin, TrashSimpleIcon } from "@phosphor-icons/react";
 import { cn } from '@/lib/utils';
 import type { MemoItem } from '@features/memo';
 
@@ -47,9 +47,9 @@ export function MemoCardActions({
       </Item>
       <Item
         onClick={() => onDelete(memo)}
-        className={cn(ITEM_BASE, "text-[var(--destructive)]")}
+        className={cn(ITEM_BASE, "hover:text-[var(--destructive)]")}
       >
-        <TrashIcon className="w-4 h-4 mr-2" /> 删除
+        <TrashSimpleIcon className="w-4 h-4 mr-2" /> 删除
       </Item>
     </>
   );

--- a/app/flowix-web/platform/tauri/client.ts
+++ b/app/flowix-web/platform/tauri/client.ts
@@ -14,19 +14,11 @@ import type { MemoColor } from '@features/memo';
 
 export type { ChatMessage } from '@/types/agent';
 
-// Lightweight message type for LLM communication (without id/timestamp)
-export interface LlmMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
-
-export interface RpcRequest {
-  <T = unknown>(method: string, params?: unknown): Promise<T>;
-}
-
 // ============================================
 // Tauri RPC Client
 // ============================================
+
+type RpcRequest = <T = unknown>(method: string, params?: unknown) => Promise<T>;
 
 let rpcInstance: RpcRequest | null = null;
 
@@ -35,17 +27,6 @@ export function initTauriClient(): void {
     return await invoke<T>(method, params as Record<string, unknown> || {});
   };
   (window as any).__tauriRpc = rpcInstance;
-}
-
-export function getRpc(): RpcRequest {
-  if (!rpcInstance) {
-    throw new Error("Tauri RPC not initialized. Call initTauriClient() first.");
-  }
-  return rpcInstance;
-}
-
-export function isInitialized(): boolean {
-  return rpcInstance !== null;
 }
 
 // ============================================
@@ -313,11 +294,11 @@ export interface AgentConfig {
   apiKey: string;
 }
 
-export interface ChatResponse {
+interface ChatResponse {
   response: string;
 }
 
-export interface AgentUserMessage {
+interface AgentUserMessage {
   content: string;
   llmContent?: string;
   systemReminderDirectory?: string;
@@ -353,6 +334,22 @@ export const agent = {
     invoke<ThreadInfo>('thread_create', { title }),
   getThread: (threadId: string) =>
     invoke<{ messages: ChatMessage[] }>('thread_get', { threadId }),
+  /**
+   * Layer 4: 分页加载 thread 历史. 返回 { messages (ASC), oldestSequence, hasMore }.
+   *  - beforeSequence = null/undefined → 取最近 limit 条
+   *  - beforeSequence = N → 取 sequence < N 的最近 limit 条 (向上翻页)
+   * 服务端 clamp limit 到 [1, 1000].
+   */
+  getThreadPage: (
+    threadId: string,
+    beforeSequence: number | null,
+    limit: number,
+  ) =>
+    invoke<{
+      messages: ChatMessage[];
+      oldestSequence: number | null;
+      hasMore: boolean;
+    }>('thread_get_page', { threadId, beforeSequence, limit }),
   listCodexThreads: () =>
     invoke<ThreadInfo[]>('codex_thread_list'),
   getCodexThread: (threadId: string) =>
@@ -381,7 +378,7 @@ export const agent = {
 // listener 长在, 永远不卸, 派发器自己按 `thread_id` 路由到正确的 store
 // 状态。 旧调用点 (chat-store.ts: sendMessageStream 里的
 // `listenToAgentStream((chunk) => ...)`) 已经整体替换为单点 dispatch。
-export type StreamCallback = (chunk: AgentChunk) => void;
+type StreamCallback = (chunk: AgentChunk) => void;
 
 // CLI sidecar JSON-RPC ── 通过后端 `cli_invoke` 命令走 `flowix-cli serve` 子进程。
 // 后端 spawn sidecar 进程, 维护 stdin/stdout 双向流, 把 method + params 包成
@@ -402,17 +399,6 @@ export function listenToAgentStream(callback: StreamCallback): UnlistenFn {
   return subscribe<AgentChunk>('agent-chunk', callback);
 }
 
-export function stopListeningToAgentStream(): void {
-  // 走 event-bus 的 reset: 清空该 event 的所有 handler。 主要供过去
-  // 的单个调用点调用, 现代代码不应该还在调 stopXxx()
-  // (业务上应该让 subscribe 的 UnlistenFn 走 useEffect cleanup)。
-  // 为保持向后兼容, 不动 state, 让 GC 自然清理。
-  //
-  // 但 chat-store 里用了 module-level bridge 实现幂等, 需要能够在
-  // 测试中完全清除. 提供 _resetForTests 走 event-bus 全量 reset,
-  // 调用点会被迁移到 reset 路径。
-}
-
 // ============================================
 // 跨窗口同步
 // ============================================
@@ -421,8 +407,8 @@ export function stopListeningToAgentStream(): void {
 // 其它窗口收到后从磁盘重新 load, 解决: 两个 Tauri 窗口各跑独立 React 树
 // + 独立 zustand store, 一边改动另一边看不到的问题。
 
-export type UserConfigChangeKind = 'preference' | 'ai_config';
-export type UserConfigChangeHandler = (kind: UserConfigChangeKind) => void;
+type UserConfigChangeKind = 'preference' | 'ai_config';
+type UserConfigChangeHandler = (kind: UserConfigChangeKind) => void;
 
 export function listenToUserConfigChanges(
   handler: UserConfigChangeHandler,
@@ -430,22 +416,21 @@ export function listenToUserConfigChanges(
   return subscribe<UserConfigChangeKind>('user-config-changed', handler);
 }
 
+// 历史兼容: useEffect cleanup 仍有人手调这个空函数(例如
+// `preferences/sections/agent.tsx`)。 内部走 event-bus.unsubscribe 不需要
+// 全量 reset, GC 自然清理就行。 不删避免破坏调用方。
 export function stopListeningToUserConfigChanges(): void {
-  // 同上, 走 event-bus 的 UnlistenFn, 业务上应该让
+  // 走 event-bus 的 UnlistenFn, 业务上应该让
   // subscribe 返回的 unlisten 走 useEffect cleanup, 不该手工调 stopXxx。
 }
 
 // Agent 可访问目录变更事件 ── 后端 set_agent_access / notebook CRUD
 // 钩子任一成功都 emit, payload 是 `()` (无 payload), 监听者直接
 // `loadInitial()` 拉整份 config。 与 `user-config-changed` 同形。
-export type AgentAccessChangeHandler = () => void;
+type AgentAccessChangeHandler = () => void;
 
 export function listenToAgentAccessChanges(
   handler: AgentAccessChangeHandler,
 ): UnlistenFn {
   return subscribe<unknown>('agent-access-changed', () => handler());
-}
-
-export function stopListeningToAgentAccessChanges(): void {
-  // 走 event-bus, 同上。
 }

--- a/app/flowix-web/shared/ui/button.tsx
+++ b/app/flowix-web/shared/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 import { Tooltip, type TooltipAlign, type TooltipSide } from "@shared/ui/tooltip"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-[color-mix(in_oklch,var(--ring)_50%,transparent)] active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:aria-invalid:border-[color-mix(in_oklch,var(--destructive)_50%,transparent)] dark:aria-invalid:ring-[color-mix(in_oklch,var(--destructive)_40%,transparent)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:aria-invalid:border-[color-mix(in_oklch,var(--destructive)_50%,transparent)] dark:aria-invalid:ring-[color-mix(in_oklch,var(--destructive)_40%,transparent)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-[color-mix(in_oklch,var(--muted)_50%,transparent)]",
         destructive:
-          "bg-[color-mix(in_oklch,var(--destructive)_10%,transparent)] text-destructive hover:bg-[color-mix(in_oklch,var(--destructive)_20%,transparent)] focus-visible:border-[color-mix(in_oklch,var(--destructive)_40%,transparent)] focus-visible:ring-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:bg-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:hover:bg-[color-mix(in_oklch,var(--destructive)_30%,transparent)] dark:focus-visible:ring-[color-mix(in_oklch,var(--destructive)_40%,transparent)]",
+          "bg-[color-mix(in_oklch,var(--destructive)_10%,transparent)] text-destructive hover:bg-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:bg-[color-mix(in_oklch,var(--destructive)_20%,transparent)] dark:hover:bg-[color-mix(in_oklch,var(--destructive)_30%,transparent)]",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/app/flowix-web/styles/editor-agent-thread-card.css
+++ b/app/flowix-web/styles/editor-agent-thread-card.css
@@ -58,7 +58,7 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
-  background: var(--card);
+  background: var(--editor-block-bg);
   color: var(--foreground);
 }
 
@@ -110,9 +110,9 @@
 
 /* 头部 ── grid auto 行, 高度由 grid-template-rows 显式控制 (40px)。
  * 取消旧的 min-height 写法, 用 height 让 grid 行严格等于 token。
- * 背景与消息区一致 (var(--card)): 头部不再走 frosted glass, 改为
- * 与 body 同色 ── 卡片视觉是一个整体, header 仅靠 1px 下边框或
- * 字重差异与 body 分区, 不再用半透明 + 模糊制造"分块感"。
+ * 背景透明,继承 container 的 --editor-block-bg: 与 body 严格同色 ──
+ * 卡片视觉是一个整体, header 仅靠 1px 下边框或字重差异与 body 分区,
+ * 不用半透明 + 模糊制造"分块感"。
  *
  * ── 圆角裁剪责任收口到 card 根 ──
  * 之前 header 自己写 border-top-left-radius + border-top-right-radius
@@ -132,12 +132,11 @@
   height: var(--atc-header-h);
   padding: 0 0.8rem;
   box-sizing: border-box;
-  /* 与 body 视觉合一: body 显式不写 background, 继承自 card 根
-   * var(--card); header 直接写同色, 头/体在视觉上是同一块, 靠
-   * 文字层级和组件内部 padding 区分。去掉 backdrop-filter ──
-   * 半透明 + 模糊只在背景透出时才有意义, 实色背景下无效果且
-   * 徒增 GPU 开销。 */
-  background: var(--card);
+  /* 与 body 视觉合一: 背景透明, header 继承 container 的
+   * --editor-block-bg, 头/体在视觉上是同一块, 靠文字层级和组件
+   * 内部 padding 区分。去掉 backdrop-filter ── 半透明 + 模糊只在
+   * 背景透出时才有意义, 实色背景下无效果且徒增 GPU 开销。 */
+  background: transparent;
 }
 
 /* 左侧: agent-role-badge (icon + role 名) + 对话标题 单行排版, 整体
@@ -727,7 +726,7 @@
  * 挂在 pre 上 (跟编辑器一致), pre code 只还原 padding 与透明背景
  * (让内层 code 不再叠加边框/底色 ── 避免双层视觉)。
  *
- *   pre:     background  color-mix(--code-block-bg 60%, transparent)
+ *   pre:     background  color-mix(--editor-block-bg 60%, transparent)
  *            border      var(--border)
  *            radius      0.5rem
  *            padding     0.5rem 1rem 1rem
@@ -746,7 +745,7 @@
   padding: 0.5rem 1rem 1rem;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  background: color-mix(in oklch, var(--code-block-bg) 60%, transparent);
+  background: color-mix(in oklch, var(--editor-block-bg) 60%, transparent);
   font-family: inherit;
   font-size: 0.85em;
   line-height: var(--app-line-height, 1.6);
@@ -883,7 +882,7 @@
   padding: 0.4rem 0.4rem 0.4rem 0.8rem;
   border: 1px solid var(--border);
   border-radius: 1rem;
-  background: var(--card);
+  background: transparent;
   box-sizing: border-box;
   max-height: 15rem;
 }

--- a/app/flowix-web/styles/editor-attachment-link.css
+++ b/app/flowix-web/styles/editor-attachment-link.css
@@ -122,8 +122,12 @@
   transition: color 0.15s ease;
 }
 
+/* 节点被 NodeSelection 选中 — 与 .editor-note-reference.is-selected 同源
+ * 走 color-mix(--document-link × transparent) 派生公式, 跨主题自动适配.
+ * 浓度 10% 与 .editor-note-reference.is-selected 对齐, inline 卡片在文本
+ * 行内不应铺大色块喧宾夺主, 视觉权重对齐 hover 反馈。 */
 .markdown-editor .tiptap .editor-file-attachment.is-selected .editor-file-attachment__card {
-  background-color: transparent;
+  background-color: color-mix(in oklch, var(--document-link) 10%, transparent);
 }
 
 .markdown-editor .tiptap .editor-image-attachment {

--- a/app/flowix-web/styles/editor-bubble-menus.css
+++ b/app/flowix-web/styles/editor-bubble-menus.css
@@ -68,7 +68,7 @@
   outline: none;
 }
 
-.table-bubble-menu .delete-table-btn:hover {
+.table-bubble-menu .destructive:hover {
   background: color-mix(in oklch, var(--destructive, #ef4444) 12%, transparent);
   color: var(--destructive, #ef4444);
 }

--- a/app/flowix-web/styles/editor-code-block.css
+++ b/app/flowix-web/styles/editor-code-block.css
@@ -31,7 +31,7 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  transform: translateX(4px);
+  transform: translateX(0.4rem);
 }
 
 .code-block-language-selector {

--- a/app/flowix-web/styles/editor.css
+++ b/app/flowix-web/styles/editor.css
@@ -118,10 +118,10 @@
 }
 
 .markdown-editor .tiptap pre  {
-  background: color-mix(in oklch, var(--code-block-bg) 60%, transparent);
+  background: color-mix(in oklch, var(--editor-block-bg) 60%, transparent);
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  padding: 0.5rem 1rem 1rem;
+  padding: 0.4rem 0.8rem 1.2rem;
   margin: 1rem 0;
   font-family: inherit;
   /* em: 跟随父级段落字号 */
@@ -253,7 +253,7 @@
 }
 
 .markdown-editor .tiptap .selectedCell {
-  background-color: rgba(82, 98, 220, 0.15) !important;
+  background-color: color-mix(in oklch, var(--brand), transparent 85%) !important;
 }
 
 /* prosemirror-tables 为列中每个 cell 插入一个 .column-resize-handle widget,
@@ -319,7 +319,7 @@
   max-width: 100%;
   position: relative;
   display: block;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.8rem;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -377,8 +377,7 @@
 }
 
 .markdown-editor .table-edge-insert-button:hover {
-  background: var(--muted, #f3f4f6);
-  border-color: color-mix(in oklch, var(--border), var(--foreground) 18%);
+  background: color-mix(in oklch, var(--card, var(--background, #fff)), var(--muted, #f3f4f6) 50%);
   color: var(--foreground, #111827);
 }
 
@@ -483,6 +482,24 @@
   border: none;
   border-top: 0.0625rem solid var(--border);
   margin: 1rem 0 2rem 0;
+  /* 让 .is-block-selected / .ProseMirror-selectednode 切到 brand 时
+   * 平滑过渡, 与其他块的高亮入场节奏一致 (120ms)。 */
+  transition: border-top-color 120ms ease-out;
+}
+
+/* hr 选中态: 复用 .is-block-selected / .ProseMirror-selectednode 的
+ * brand 色相, 但 hr 是 1px 边线、box 高度近乎 0, 通用规则的背景色铺
+ * 不到线上, 视觉上读不出"被选中"。改为把 border-top 直接切到 brand
+ * 作为唯一视觉锚 ——
+ *   - is-block-selected: drag context menu 钉住 (与通用 .is-block-selected
+ *     的 inset left stripe 共用, 形成 "线 + 左竖条" 的组合指示);
+ *   - ProseMirror-selectednode: NodeSelection (点击 hr 直接选中),
+ *     不再加 outline / box-shadow 等外框 — hr 自身就是 1px 边, 高亮
+ *     只在线本身, 视觉更克制。
+ * 选择器特异性 (0,3,1) 高于全局 .ProseMirror-selectednode (0,1,0)。 */
+.markdown-editor .ProseMirror hr.is-block-selected,
+.markdown-editor .ProseMirror hr.ProseMirror-selectednode {
+  border-top-color: var(--brand);
 }
 
 .markdown-editor .tag-node {
@@ -526,6 +543,15 @@
 
 .markdown-editor .ProseMirror .is-block-selected:hover {
   background-color: color-mix(in oklch, var(--brand) 10%, transparent);
+}
+
+.markdown-editor .ProseMirror .flowix-block-drop-indicator {
+  display: block;
+  height: 2px;
+  margin: 3px 0;
+  border-radius: 999px;
+  background: var(--brand);
+  pointer-events: none;
 }
 
 /* 节点级选中 (image / videoAttachment / fileAttachment 等

--- a/app/flowix-web/styles/index.css
+++ b/app/flowix-web/styles/index.css
@@ -199,6 +199,14 @@
 	}
 }
 
+/* Global keyboard focus ring for native buttons and shared Button instances.
+ * Keep this unlayered and after Tailwind utilities so buttons that do not use
+ * shared/ui/Button still get the same system ring token when reached by Tab. */
+:where(button, [role="button"]):focus-visible:not(:disabled):not([aria-disabled="true"]) {
+	outline: none;
+	box-shadow: 0 0 0 1px var(--ring);
+}
+
 /* agent-* 元素的样式已合并到组件 className (Tailwind 工具类);
  * 关键帧由 animate-[<name>_<duration>_<timing>] arbitrary value 引用,
  * 必须保留 CSS。 */

--- a/app/flowix-web/styles/theme/dark.css
+++ b/app/flowix-web/styles/theme/dark.css
@@ -24,7 +24,8 @@
 	--border: oklch(0.284 0.014 var(--neutral-hue));
 	--input: var(--border);
 	--divider: color-mix(in oklch, var(--background) 50%, var(--border));
-	--ring: oklch(0.375 0.027 var(--neutral-hue));
+	/* Keyboard focus ring follows the theme primary color. */
+	--ring: var(--primary);
 
 	/* 代理面板: 沿用 titlebar 同值, 解耦后改这里 */
 	--agent-bg: oklch(0.173 0.009 var(--neutral-hue));
@@ -53,7 +54,7 @@
 	--memo-color-gray:   oklch(64% 0.015 264);
 
 	--code-bg: oklch(0.229 0.018 275);
-	--code-block-bg: oklch(0.176 0.014 var(--neutral-hue));
+	--editor-block-bg: oklch(0.176 0.014 var(--neutral-hue));
 
 	--floating-bg: oklch(0.213 0.013 var(--neutral-hue));
 	/* 浮层文字: 与 floating-bg 配对, 三主题统一柔和白, 避纯白在深底的眩光 */

--- a/app/flowix-web/styles/theme/light.css
+++ b/app/flowix-web/styles/theme/light.css
@@ -24,7 +24,8 @@
 	--border: oklch(0.928 0.006 var(--neutral-hue));
 	--input: var(--border);
 	--divider: color-mix(in oklch, var(--background) 50%, var(--border));
-	--ring: oklch(0.804 0.020 var(--neutral-hue));
+	/* Keyboard focus ring follows the theme primary color. */
+	--ring: var(--primary);
 
 	/* 代理面板: 沿用 titlebar 同值, 解耦后改这里 */
 	--agent-bg: oklch(0.979 0 0);
@@ -55,7 +56,7 @@
 	--memo-color-gray:   oklch(58% 0.015 264);
 
 	--code-bg: oklch(0.938 0.003 286);
-	--code-block-bg: oklch(1 0 0);
+	--editor-block-bg: oklch(1 0 0);
 
 	--floating-bg: oklch(0.321 0 0);
 	/* 浮层文字: 与 floating-bg 配对, 三主题统一柔和白, 避纯白在深底的眩光 */

--- a/app/flowix-web/styles/theme/rock.css
+++ b/app/flowix-web/styles/theme/rock.css
@@ -19,14 +19,18 @@
 
 	--secondary: oklch(0.904 0.011 var(--neutral-hue));
 	--secondary-foreground: oklch(0.372 0.009 var(--neutral-hue));
-	--muted: oklch(0.885 0.015 var(--neutral-hue));
-	--muted-foreground: oklch(0.576 0.014 var(--neutral-hue));
+	/* 弱化: muted 向 background 拉近 (ΔL 0.033 → 0.013) 并消色 (chroma 0.015 → 0.009),
+	 * 让 hover / 用户消息气泡 / 头像块这些面读作"纸面浮起"而非"色块凸出" */
+	--muted: oklch(0.905 0.009 var(--neutral-hue));
+	/* muted-foreground 同步提亮, 向 light 主题 0.613 看齐, 文字不再比 light 更沉 */
+	--muted-foreground: oklch(0.605 0.012 var(--neutral-hue));
 	--accent: oklch(0.904 0.011 var(--neutral-hue));
 
 	--border: oklch(0.861 0.009 var(--neutral-hue));
 	--input: var(--border);
 	--divider: color-mix(in oklch, var(--background) 50%, var(--border));
-	--ring: oklch(0.770 0.013 var(--neutral-hue));
+	/* Keyboard focus ring follows the theme primary color. */
+	--ring: var(--primary);
 
 	/* 代理面板: 沿用 titlebar 同值, 解耦后改这里 */
 	--agent-bg: oklch(0.944 0.010 var(--neutral-hue));
@@ -36,7 +40,7 @@
 
 	--bg-titlebar: oklch(0.934 0.010 var(--neutral-hue));
 	/* 文档: 在 background 上提一档亮度, 让编辑器外侧到窗口边的留白读作"温润纸边" */
-	--document-bg: oklch(0.961 0.008 var(--neutral-hue));
+	--document-bg: oklch(0.98 0.003 var(--neutral-hue));
 	--document-foreground: oklch(0.379 0.009 var(--neutral-hue));
 	/* 链接: L=0.42 "冷却中岩浆" 锚定浅橄榄底, 改同色系深浅对比, 对比 11.77:1 */
 	--document-link: oklch(0.42 0.18 var(--brand-hue));
@@ -57,7 +61,7 @@
 	--memo-color-gray:   oklch(54% 0.012 92);
 
 	--code-bg: oklch(0.894 0.014 var(--neutral-hue));
-	--code-block-bg: oklch(0.985 0 0);
+	--editor-block-bg: oklch(0.985 0 0);
 
 	--floating-bg: oklch(0.323 0.007 var(--neutral-hue));
 	/* 浮层文字: 与 floating-bg 配对, 三主题统一柔和白, 避纯白在深底的眩光 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@phosphor-icons/react": "^2.1.10",
+        "@tanstack/react-virtual": "^3.14.3",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "@tiptap/extension-color": "^3.23.4",
@@ -2373,6 +2374,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@phosphor-icons/react": "^2.1.10",
+    "@tanstack/react-virtual": "^3.14.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tiptap/extension-color": "^3.23.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,8 @@ export default {
         background: "var(--background)",
         foreground: "var(--foreground)",
         border: "var(--border)",
+        input: "var(--input)",
+        ring: "var(--ring)",
 
         card: {
           DEFAULT: "var(--card)",


### PR DESCRIPTION
… refactor

- 拆分代理工具消息渲染（message-tool / message-end / message-reasoning 等）
- document-titlebar 按平台拆分为 mac / shared / win
- drag-context-menu 重构：拆分 actions / block-info / icons / positioning，新增 block-action-menu / block-menu-actions / use-drag-handle-position / block-drag 扩展
- 代码块 shiki 视图与装饰器调整
- 主题 CSS（dark / light / rock）与编辑器样式微调
- 平台层 tauri client 与 editor markdown 微调
- tab-agent-run 扩展新增