### PR TITLE
fix(agent): detect Codex bundled with ChatGPT.app

### DIFF
--- a/app/flowix-desktop/src/external_runtime/codex/cli.rs
+++ b/app/flowix-desktop/src/external_runtime/codex/cli.rs
@@ -1,5 +1,7 @@
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+#[cfg(not(windows))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -753,25 +755,37 @@ pub(crate) fn resolve_codex_binary() -> PathBuf {
 
         // GUI 启动时 launchd 给的 PATH 极简（/usr/bin:/bin:/usr/sbin:/sbin），
         // shell 里的 PATH 一律拿不到。挨个查常见安装位置作为回退。
-        if let Some(home) = dirs::home_dir() {
-            let candidates = [
-                home.join(".npm-global/bin/codex"),
-                home.join(".npm/bin/codex"),
-                home.join(".local/bin/codex"),
-                home.join(".cargo/bin/codex"),
-                home.join(".bun/bin/codex"),
-                home.join(".volta/bin/codex"),
-                PathBuf::from("/opt/homebrew/bin/codex"),
-                PathBuf::from("/usr/local/bin/codex"),
-            ];
-            for candidate in candidates {
-                if candidate.is_file() {
-                    return candidate;
-                }
+        for candidate in codex_fallback_candidates(dirs::home_dir().as_deref()) {
+            if candidate.is_file() {
+                return candidate;
             }
         }
         PathBuf::from("codex")
     }
+}
+
+#[cfg(not(windows))]
+fn codex_fallback_candidates(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(home) = home {
+        candidates.extend([
+            home.join(".npm-global/bin/codex"),
+            home.join(".npm/bin/codex"),
+            home.join(".local/bin/codex"),
+            home.join(".cargo/bin/codex"),
+            home.join(".bun/bin/codex"),
+            home.join(".volta/bin/codex"),
+        ]);
+    }
+    candidates.extend([
+        PathBuf::from("/opt/homebrew/bin/codex"),
+        PathBuf::from("/usr/local/bin/codex"),
+    ]);
+    #[cfg(target_os = "macos")]
+    candidates.push(PathBuf::from(
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+    ));
+    candidates
 }
 
 /// 在当前 `PATH` 里找名为 `codex` 的可执行文件（仅普通文件，避开目录）。
@@ -1447,6 +1461,16 @@ mod tests {
             resolved,
             std::env::temp_dir().join("flowix-nonexistent-codex-cli-path")
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn codex_fallback_candidates_include_chatgpt_app_binary() {
+        let candidates = codex_fallback_candidates(None);
+
+        assert!(candidates.contains(&PathBuf::from(
+            "/Applications/ChatGPT.app/Contents/Resources/codex"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## What

Add the Codex executable bundled with the macOS ChatGPT desktop app to Flowix’s fallback runtime candidates. The fallback list is now generated by a small helper so the platform-specific path can be covered by a regression test.

## Why

Flowix launched from Finder or the Dock does not inherit the terminal PATH. Users whose working Codex CLI comes from `/Applications/ChatGPT.app/Contents/Resources/codex` are therefore marked unavailable, and Codex is hidden from the `/` agent menu. This should work without requiring a manual symlink.

Fixes #3.

## How tested

- [ ] `cargo test --workspace` — not run in full; the focused Codex module ran 26/27 tests, with one pre-existing failure because the Node fallback test rejects the valid local NVM path.
- [ ] `cargo fmt --check` — blocked by pre-existing formatting differences across the workspace.
- [ ] `cargo clippy --workspace -- -D warnings` — not run because the current crate already emits baseline warnings under `cargo check`.
- [ ] `npm run lint` — not available in this environment (`npm` is not installed).
- [x] `cargo test --manifest-path app/Cargo.toml -p flowix-desktop codex_fallback_candidates_include_chatgpt_app_binary`
- [x] `cargo check --manifest-path app/Cargo.toml -p flowix-desktop`
- [x] `git diff --check`
- [x] Manual verification: confirmed `/Applications/ChatGPT.app/Contents/Resources/codex` exists and reports `codex-cli 0.144.0-alpha.4` on macOS.

## Risks

Low. Existing resolution priority is unchanged: `CODEX_CLI_PATH`, process PATH, and common installation directories are still checked first. The ChatGPT.app path is a final macOS-only fallback.

## Checklist

- [x] No secrets / tokens / `.env` files touched
- [x] No force-push to `main`
- [x] No interface or schema change
