### PR TITLE
fix(editor): stop bubble menu render loop; decouple sidebar collapse

### DIFF
--- a/app/flowix-web/features/editor/components/selection-bubble-menu.tsx
+++ b/app/flowix-web/features/editor/components/selection-bubble-menu.tsx
@@ -11,7 +11,8 @@ import {
   TextStrikethroughIcon,
   TextUnderlineIcon,
 } from '@phosphor-icons/react';
-import { type ReactNode, useEffect, useReducer } from 'react';
+import { type ReactNode, useCallback, useEffect, useMemo, useReducer } from 'react';
+import type { BubbleMenuProps } from '@tiptap/react/menus';
 import { openLinkEditPopup } from '@features/editor/components/link-edit-popup';
 import { hasFormattableTextSelection } from '@features/editor/components/selection-bubble-menu-state';
 import { useI18n } from '@features/i18n';
@@ -67,6 +68,30 @@ export function SelectionBubbleMenu({ editor }: SelectionBubbleMenuProps) {
     };
   }, [editor]);
 
+  // These props feed tiptap's internal "updateOptions" effect, whose deps
+  // include shouldShow / options / appendTo. Fresh identities each render would
+  // make that effect dispatch a transaction every render, which our
+  // transaction listener above turns back into a re-render → infinite loop
+  // ("Maximum update depth exceeded"). Memoize to keep identities stable.
+  const appendTo = useCallback((): HTMLElement => document.body, []);
+  const shouldShow = useCallback<NonNullable<BubbleMenuProps['shouldShow']>>(
+    ({ element, view }) =>
+      (view.hasFocus() || element.contains(document.activeElement)) &&
+      hasFormattableTextSelection(editor),
+    [editor],
+  );
+  const options = useMemo<BubbleMenuProps['options']>(
+    () => ({
+      strategy: 'fixed',
+      placement: 'top',
+      offset: 8,
+      flip: { padding: 8 },
+      shift: { padding: 8 },
+      inline: true,
+    }),
+    [],
+  );
+
   const linkHref = editor.isActive('link')
     ? String(editor.getAttributes('link').href ?? '')
     : '';
@@ -78,19 +103,9 @@ export function SelectionBubbleMenu({ editor }: SelectionBubbleMenuProps) {
       role="toolbar"
       aria-label={t('editor.bubble.formatting')}
       updateDelay={80}
-      appendTo={() => document.body}
-      shouldShow={({ element, view }) =>
-        (view.hasFocus() || element.contains(document.activeElement)) &&
-        hasFormattableTextSelection(editor)
-      }
-      options={{
-        strategy: 'fixed',
-        placement: 'top',
-        offset: 8,
-        flip: { padding: 8 },
-        shift: { padding: 8 },
-        inline: true,
-      }}
+      appendTo={appendTo}
+      shouldShow={shouldShow}
+      options={options}
     >
       <FormatButton
         active={editor.isActive('bold')}

--- a/app/flowix-web/features/shell/main-layout.tsx
+++ b/app/flowix-web/features/shell/main-layout.tsx
@@ -285,26 +285,18 @@ export function MainLayout() {
     setNoteNavigationVisible(!noteNavigationVisible);
   }, [noteNavigationVisible, setNoteNavigationVisible]);
 
-  // 关闭 memo-list 侧栏时同步收起笔记导航 ── 避免左侧两列同时打开占满
-  // 视口宽度。手势 (左滑) 走 resolvePanelSwipeTransition, 不经过此路径,
-  // 不会触发级联关闭, 与手势的「只关一个」语义保持一致。
-  const closeMemoListAndNoteNavigation = useCallback(() => {
+  // memo-list 侧栏折叠只关自己, 不再级联收起笔记导航 ── 两者是独立的可见性,
+  // 与键盘 (⌘L, toggleMemoListVisible) 和手势 (resolvePanelSwipeTransition)
+  // 的「只关一个」语义保持一致。之前的级联让用户折叠侧栏时意外丢失笔记导航,
+  // 且折叠后无法单独恢复, 交互难用。
+  const handleCollapseMemoList = useCallback(() => {
     setMemoListVisible(false);
-    if (noteNavigationVisible) {
-      setNoteNavigationVisible(false);
-    }
-  }, [noteNavigationVisible, setMemoListVisible, setNoteNavigationVisible]);
+  }, [setMemoListVisible]);
 
-  // document 顶栏的侧栏 toggle: 打开走纯开, 关闭走级联 (带笔记导航),
-  // 行为与 memo-list 顶栏的折叠按钮对齐 ── 任一入口关闭都同步收起左侧
-  // 两列。
+  // document 顶栏的侧栏 toggle: 纯粹开/关 memo-list, 不牵连笔记导航。
   const handleToggleMemoList = useCallback(() => {
-    if (memoListVisible) {
-      closeMemoListAndNoteNavigation();
-    } else {
-      setMemoListVisible(true);
-    }
-  }, [closeMemoListAndNoteNavigation, memoListVisible, setMemoListVisible]);
+    setMemoListVisible(!memoListVisible);
+  }, [memoListVisible, setMemoListVisible]);
 
   const currentMemo = currentDocumentPath && currentDocumentSource === 'memo' && activeMemoSession
     ? memos.find((memo) => memo.id === activeMemoSession.memoId)
@@ -544,14 +536,14 @@ export function MainLayout() {
             >
               {isWindowsPlatform() ? (
                 <MemoListTitlebarWin
-                  onCollapseSidebar={closeMemoListAndNoteNavigation}
+                  onCollapseSidebar={handleCollapseMemoList}
                   onToggleNoteNavigation={handleToggleNoteNavigation}
                   onOpenPreferences={() => windows.openPreferences()}
                 />
               ) : (
                 <MemoListTitlebarMac
                   noteNavigationVisible={noteNavigationVisible}
-                  onCollapseSidebar={closeMemoListAndNoteNavigation}
+                  onCollapseSidebar={handleCollapseMemoList}
                   onToggleNoteNavigation={handleToggleNoteNavigation}
                   onOpenPreferences={() => windows.openPreferences()}
                 />


### PR DESCRIPTION
## Summary

Fixes two reported UX bugs in the note editor and layout, both root-caused to the recently merged selection-bubble-toolbar and an intentional-but-unwanted collapse cascade.

### 1. `Maximum update depth exceeded` + broken link button (same root cause)
`SelectionBubbleMenu` passed **fresh inline identities** for `shouldShow`, `options`, and `appendTo` to `@tiptap/react`'s `<BubbleMenu>`. That wrapper has an internal `updateOptions` effect whose dependency array includes exactly those three props. So on every render:

1. `SelectionBubbleMenu` renders → new prop identities.
2. `<BubbleMenu>`'s effect sees changed deps → `view.dispatch(tr.setMeta(..., 'updateOptions'))` — a ProseMirror transaction.
3. The component's own `editor.on('transaction', rerender)` listener fires → `setState`.
4. Re-render → back to step 2. **Infinite loop.**

This is what React reports as *Maximum update depth exceeded*. It also explains why the **link button seemed to need a long-press and never applied a link**: the constant re-render/transaction churn thrashed the bubble DOM and selection, so a normal click rarely landed on a stable target. Bold/italic/etc. use the identical button but are less sensitive because they don't open a detached popup that reads the live selection.

**Fix:** memoize the three props with `useMemo`/`useCallback` so their identities stay stable and tiptap's effect stops dispatching a transaction on every render. The link-apply logic in `link-edit-popup.tsx` was already correct once the selection is stable, so no change was needed there.

### 2. Collapsing the sidebar also collapsed the note-navigation panel
`main-layout.tsx` had a `closeMemoListAndNoteNavigation` cascade wired into the memo-list collapse button and the document-titlebar sidebar toggle: closing the memo-list sidebar force-closed the note-navigation panel too, and it couldn't be recovered without going through a menu. Meanwhile the keyboard shortcut (⌘L) and the trackpad-swipe path were already decoupled ("close only one"), so the buttons behaved inconsistently.

**Fix:** collapse now only affects its own panel. `handleCollapseMemoList` closes just the memo list; `handleToggleMemoList` is a pure toggle. Behavior now matches the keyboard and swipe paths.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vite build` passes
- [ ] Select text → bubble toolbar appears with no console loop error
- [ ] Click (single click, no long-press) the link button → popup opens; enter URL + Save → link applied to selection
- [ ] Collapse the memo-list sidebar → note-navigation panel stays as it was
- [ ] ⌘L and trackpad swipe still behave as before