### PR TITLE
feat(agent): render and copy LaTeX in thread cards

### DIFF
--- a/app/flowix-web/features/agent/thread-card/agent-thread-card-cache.test.ts
+++ b/app/flowix-web/features/agent/thread-card/agent-thread-card-cache.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const agentConversationStoreMock = vi.hoisted(() => ({
   loadMessages: vi.fn(async () => undefined),
+  messageStates: {},
 }));
 
 vi.mock('@features/agent/store/agent-conversation-store', () => ({
@@ -38,10 +39,11 @@ describe('agent thread card cache helper', () => {
     expect(result).toEqual({
       resolvedSessionId: null,
       loadedThreadId: 'flowix-thread',
+      messages: [],
     });
   });
 
-  it('returns a resolved Codex session without loading when local id is resolved', async () => {
+  it('loads a resolved Codex session before replacing its local id', async () => {
     const { resolveExternalSessionId } = await import('@features/agent/services/external-agent-runtime-service');
     vi.mocked(resolveExternalSessionId).mockResolvedValueOnce('codex-real-session');
     const { loadAgentThreadCardCache } = await import('./agent-thread-card-cache');
@@ -53,9 +55,13 @@ describe('agent thread card cache helper', () => {
 
     expect(result).toEqual({
       resolvedSessionId: 'codex-real-session',
-      loadedThreadId: null,
+      loadedThreadId: 'codex-real-session',
+      messages: [],
     });
-    expect(agentConversationStoreMock.loadMessages).not.toHaveBeenCalled();
+    expect(agentConversationStoreMock.loadMessages).toHaveBeenCalledWith(
+      'codex',
+      'codex-real-session'
+    );
   });
 
   it('loads Codex history for a resolved session id', async () => {

--- a/app/flowix-web/features/agent/thread-card/agent-thread-card-cache.ts
+++ b/app/flowix-web/features/agent/thread-card/agent-thread-card-cache.ts
@@ -1,4 +1,5 @@
 import type { AgentTypeKey } from '@/types/agent';
+import type { ChatMessage } from '@/types';
 import { getAgentType } from '@/lib/agent-types';
 import { useAgentConversationStore } from '@features/agent/store/agent-conversation-store';
 import {
@@ -14,6 +15,17 @@ export interface LoadAgentThreadCardCacheInput {
 export interface LoadAgentThreadCardCacheResult {
   resolvedSessionId: string | null;
   loadedThreadId: string | null;
+  messages: ChatMessage[];
+}
+
+async function loadThreadMessages(
+  typeKey: AgentTypeKey,
+  threadId: string
+): Promise<ChatMessage[]> {
+  await useAgentConversationStore.getState().loadMessages(typeKey, threadId);
+  return (
+    useAgentConversationStore.getState().messageStates[threadId]?.messages ?? []
+  );
 }
 
 export async function loadAgentThreadCardCache(
@@ -29,17 +41,22 @@ export async function loadAgentThreadCardCache(
       : threadId;
 
     if (isLocalThreadId && sessionId && sessionId !== threadId) {
-      return { resolvedSessionId: sessionId, loadedThreadId: null };
+      const messages = await loadThreadMessages(typeKey, sessionId);
+      return {
+        resolvedSessionId: sessionId,
+        loadedThreadId: sessionId,
+        messages,
+      };
     }
 
     if (sessionId) {
-      await useAgentConversationStore.getState().loadMessages(typeKey, sessionId);
-      return { resolvedSessionId: null, loadedThreadId: sessionId };
+      const messages = await loadThreadMessages(typeKey, sessionId);
+      return { resolvedSessionId: null, loadedThreadId: sessionId, messages };
     }
 
-    return { resolvedSessionId: null, loadedThreadId: null };
+    return { resolvedSessionId: null, loadedThreadId: null, messages: [] };
   }
 
-  await useAgentConversationStore.getState().loadMessages(typeKey, threadId);
-  return { resolvedSessionId: null, loadedThreadId: threadId };
+  const messages = await loadThreadMessages(typeKey, threadId);
+  return { resolvedSessionId: null, loadedThreadId: threadId, messages };
 }

--- a/app/flowix-web/features/agent/thread-card/agent-thread-card-markdown.test.ts
+++ b/app/flowix-web/features/agent/thread-card/agent-thread-card-markdown.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fillWithAgentThreadCardMarkdownHtml,
+  renderAgentThreadCardMarkdownToHtml,
+} from "@features/agent/thread-card/agent-thread-card-markdown";
+
+function countMathNodes(html: string): number {
+  return html.match(/data-latex=/g)?.length ?? 0;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, "clipboard");
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("agent thread card Markdown math", () => {
+  it("recognizes Codex inline LaTeX delimiters", () => {
+    const html = renderAgentThreadCardMarkdownToHtml(
+      "Assume \\(q,k\\in\\mathbb R^d\\).",
+    );
+
+    expect(html).toContain("agent-thread-card__math--inline");
+    expect(html).toContain('data-latex="q,k\\in\\mathbb R^d"');
+  });
+
+  it("wraps display math in a horizontal scroller", () => {
+    const html = renderAgentThreadCardMarkdownToHtml(
+      "\\[S_tq_t\\in\\mathbb R^d\\] after",
+    );
+
+    expect(html).toContain("agent-thread-card__math--block");
+    expect(html).toContain("agent-thread-card__math-scroller");
+    expect(html).toContain('data-latex="S_tq_t\\in\\mathbb R^d"');
+    expect(html).toContain("after");
+  });
+
+  it("recognizes double-dollar display math", () => {
+    const html = renderAgentThreadCardMarkdownToHtml(
+      "$$\n\\sum_{k=1}^{n} k\n$$\nafter",
+    );
+
+    expect(countMathNodes(html)).toBe(1);
+    expect(html).toContain("agent-thread-card__math--block");
+    expect(html).toContain('data-latex="\\sum_{k=1}^{n} k"');
+    expect(html).toContain("after");
+  });
+
+  it("waits for the closing delimiter before rendering streaming math", () => {
+    expect(
+      countMathNodes(renderAgentThreadCardMarkdownToHtml("before \\[x^2")),
+    ).toBe(0);
+    expect(
+      countMathNodes(renderAgentThreadCardMarkdownToHtml("before\n\\[x^2\\]")),
+    ).toBe(1);
+  });
+
+  it("leaves fenced and multiline inline code untouched", () => {
+    const html = renderAgentThreadCardMarkdownToHtml(
+      "```md\n~~~\n\\(x\\)\n```\n\n`alpha\n\\(y\\)\nomega`",
+    );
+
+    expect(countMathNodes(html)).toBe(0);
+  });
+
+  it("does not replace ordinary text or parse link destinations", () => {
+    const html = renderAgentThreadCardMarkdownToHtml(
+      "FLOWIX_MATH_INLINE_0 [docs](https://example.com/\\(x\\)) and \\(y\\)",
+    );
+
+    expect(countMathNodes(html)).toBe(1);
+    expect(html).toContain("FLOWIX_MATH_INLINE_0");
+    expect(html).toContain("<a href=");
+    expect(html).toContain('data-latex="y"');
+  });
+
+  it("renders KaTeX and copies the original LaTeX", async () => {
+    const writeText = vi.fn(async (_value: string) => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    fillWithAgentThreadCardMarkdownHtml(
+      container,
+      renderAgentThreadCardMarkdownToHtml("\\[x^2\\]"),
+      "复制 LaTeX",
+    );
+
+    await vi.waitFor(() => {
+      expect(container.querySelector(".katex")).not.toBeNull();
+    });
+
+    const math = container.querySelector<HTMLElement>(
+      ".agent-thread-card__math",
+    );
+    expect(
+      math?.querySelector(".agent-thread-card__math-scroller .katex-display"),
+    ).not.toBeNull();
+    expect(
+      math?.querySelector('.vlist > span[style*="top"]'),
+    ).not.toBeNull();
+    expect(math?.hasAttribute("data-math-probe")).toBe(false);
+    expect(math?.hasAttribute("data-math-debug")).toBe(false);
+    expect(math?.getAttribute("aria-label")).toBe("复制 LaTeX");
+    expect(math?.title).toBe("复制 LaTeX");
+
+    math?.click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("x^2");
+    });
+    expect(math?.classList.contains("agent-thread-card__math--copied")).toBe(
+      true,
+    );
+
+    writeText.mockClear();
+    math?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("x^2");
+    });
+
+    writeText.mockClear();
+    math?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+    );
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("x^2");
+    });
+  });
+});

--- a/app/flowix-web/features/agent/thread-card/agent-thread-card-markdown.ts
+++ b/app/flowix-web/features/agent/thread-card/agent-thread-card-markdown.ts
@@ -72,10 +72,117 @@ export function decodeAgentThreadCardInputImages(
   }
 }
 
+type KatexModule = typeof import("katex");
+
+const AGENT_MATH_SELECTOR = ".agent-thread-card__math[data-latex]";
+const BLOCK_MATH_RE =
+  /^ {0,3}(?:\\\[([\s\S]*?)\\\]|\$\$([\s\S]*?)\$\$)/;
+const BLOCK_MATH_START_RE = /^ {0,3}(?:\\\[|\$\$)/m;
+const INLINE_MATH_RE = /^\\\(([\s\S]*?)\\\)/;
+const mathCopyContainers = new WeakSet<HTMLElement>();
+let katexPromise: Promise<KatexModule> | null = null;
+let katexLoaded: KatexModule | null = null;
+
+function escapeAgentThreadCardHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeAgentThreadCardHtmlAttr(value: string): string {
+  return escapeAgentThreadCardHtml(value)
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function ensureAgentThreadCardKatex(): Promise<KatexModule> {
+  if (katexLoaded) return Promise.resolve(katexLoaded);
+  if (!katexPromise) {
+    katexPromise = Promise.all([
+      import("katex"),
+      import("katex/dist/katex.min.css"),
+    ])
+      .then(([module]) => {
+        katexLoaded = module;
+        return module;
+      })
+      .catch((error) => {
+        katexPromise = null;
+        throw error;
+      });
+  }
+  return katexPromise;
+}
+
+function renderAgentMathHtml(latex: string, displayMode: boolean): string {
+  const normalizedLatex = latex.trim();
+  const className = displayMode
+    ? "agent-thread-card__math agent-thread-card__math--block"
+    : "agent-thread-card__math agent-thread-card__math--inline";
+  const attrLatex = escapeAgentThreadCardHtmlAttr(normalizedLatex);
+  const escapedLatex = escapeAgentThreadCardHtml(normalizedLatex);
+  const content = displayMode
+    ? `<span class="agent-thread-card__math-scroller">${escapedLatex}</span>`
+    : escapedLatex;
+
+  return `<span class="${className}" data-latex="${attrLatex}" data-display-mode="${displayMode ? "block" : "inline"}" role="button" tabindex="0">${content}</span>`;
+}
+
+/**
+ * 行为约束：
+ * - 数学语法必须由 Marked tokenizer 识别，让 Markdown lexer 统一处理代码、链接和转义边界。
+ * - tokenizer 只消费到公式结束符，结束符后的 Markdown 必须继续参与解析。
+ * - data-latex 始终保存原始公式；KaTeX 只替换展示内容，复制功能不得依赖渲染后的 DOM。
+ */
 const cardMarked = new Marked({
   async: false,
   gfm: true,
   breaks: true,
+});
+
+cardMarked.use({
+  extensions: [
+    {
+      name: "agentMathBlock",
+      level: "block",
+      start(src) {
+        return BLOCK_MATH_START_RE.exec(src)?.index;
+      },
+      tokenizer(src) {
+        const match = BLOCK_MATH_RE.exec(src);
+        if (!match) return;
+        return {
+          type: "agentMathBlock",
+          raw: match[0],
+          text: match[1] ?? match[2] ?? "",
+        };
+      },
+      renderer(token) {
+        return `${renderAgentMathHtml(token.text, true)}\n`;
+      },
+    },
+    {
+      name: "agentMathInline",
+      level: "inline",
+      start(src) {
+        const index = src.indexOf("\\(");
+        return index >= 0 ? index : undefined;
+      },
+      tokenizer(src) {
+        const match = INLINE_MATH_RE.exec(src);
+        if (!match) return;
+        return {
+          type: "agentMathInline",
+          raw: match[0],
+          text: match[1],
+        };
+      },
+      renderer(token) {
+        return renderAgentMathHtml(token.text, false);
+      },
+    },
+  ],
 });
 
 export function renderAgentThreadCardMarkdownToHtml(content: string): string {
@@ -83,9 +190,88 @@ export function renderAgentThreadCardMarkdownToHtml(content: string): string {
   return cardMarked.parse(content) as string;
 }
 
+function findAgentMathElement(
+  container: HTMLElement,
+  target: EventTarget | null,
+): HTMLElement | null {
+  if (!(target instanceof Element)) return null;
+  const math = target.closest<HTMLElement>(AGENT_MATH_SELECTOR);
+  return math && container.contains(math) ? math : null;
+}
+
+async function copyAgentMath(math: HTMLElement): Promise<void> {
+  const latex = math.dataset.latex;
+  if (!latex || !navigator.clipboard?.writeText) return;
+
+  try {
+    await navigator.clipboard.writeText(latex);
+    math.classList.add("agent-thread-card__math--copied");
+    window.setTimeout(() => {
+      math.classList.remove("agent-thread-card__math--copied");
+    }, 700);
+  } catch {
+    // Clipboard access is optional in browser previews and may be denied.
+  }
+}
+
+function attachAgentThreadCardMathCopyHandlers(container: HTMLElement): void {
+  if (mathCopyContainers.has(container)) return;
+  mathCopyContainers.add(container);
+
+  container.addEventListener("click", (event) => {
+    const math = findAgentMathElement(container, event.target);
+    if (!math) return;
+    event.stopPropagation();
+    void copyAgentMath(math);
+  });
+
+  container.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    const math = findAgentMathElement(container, event.target);
+    if (!math) return;
+    event.preventDefault();
+    event.stopPropagation();
+    void copyAgentMath(math);
+  });
+}
+
+async function renderAgentThreadCardMath(container: HTMLElement): Promise<void> {
+  const mathNodes = Array.from(
+    container.querySelectorAll<HTMLElement>(AGENT_MATH_SELECTOR),
+  );
+  if (!mathNodes.length) return;
+
+  let katex: KatexModule;
+  try {
+    katex = await ensureAgentThreadCardKatex();
+  } catch {
+    return;
+  }
+
+  mathNodes.forEach((math) => {
+    const latex = math.dataset.latex;
+    if (!latex || math.dataset.katexRendered === "true") return;
+    const renderTarget =
+      math.querySelector<HTMLElement>(".agent-thread-card__math-scroller") ??
+      math;
+
+    try {
+      katex.render(latex, renderTarget, {
+        displayMode: math.dataset.displayMode === "block",
+        throwOnError: false,
+        strict: false,
+      });
+      math.dataset.katexRendered = "true";
+    } catch {
+      renderTarget.textContent = latex;
+    }
+  });
+}
+
 export function fillWithAgentThreadCardMarkdownHtml(
   container: HTMLElement,
   html: string,
+  mathCopyLabel = "Copy LaTeX",
 ): void {
   container.replaceChildren();
   if (!html) return;
@@ -93,6 +279,12 @@ export function fillWithAgentThreadCardMarkdownHtml(
   const template = document.createElement("template");
   template.innerHTML = html;
   container.append(template.content.cloneNode(true));
+  container.querySelectorAll<HTMLElement>(AGENT_MATH_SELECTOR).forEach((math) => {
+    math.setAttribute("aria-label", mathCopyLabel);
+    math.title = mathCopyLabel;
+  });
+  attachAgentThreadCardMathCopyHandlers(container);
+  void renderAgentThreadCardMath(container);
 }
 
 export function parseAgentThreadCardMarkdown(token: unknown) {

--- a/app/flowix-web/features/agent/thread-card/agent-thread-card-view.tsx
+++ b/app/flowix-web/features/agent/thread-card/agent-thread-card-view.tsx
@@ -417,6 +417,8 @@ export class AgentThreadCardView implements ProseMirrorNodeView {
       getMessageCount: () => this.currentMessages().length,
       shouldLoadThreadMessages: () => this.shouldLoadThreadMessages(),
       renderThreadState: () => this.renderThreadState(),
+      renderResolvedSessionMessages: (messages) =>
+        this.renderResolvedSessionMessages(messages),
       applyResolvedSession: (threadId, sessionId, typeKey) => {
         this.applyResolvedExternalSessionId(threadId, sessionId, typeKey);
       },
@@ -1141,6 +1143,20 @@ export class AgentThreadCardView implements ProseMirrorNodeView {
     this.messages.render({
       messages,
       isLoading: runtimeView.showLoadingIndicator,
+      shouldRenderMessages,
+    });
+  }
+
+  private renderResolvedSessionMessages(
+    messages: ThreadState["messages"],
+  ): void {
+    if (this.isDestroyed || !this.dom.isConnected) return;
+    if (messages.length === 0) return;
+    const shouldRenderMessages = !this.collapsed || this.isFullscreen;
+    this.dom.classList.remove("agent-thread-card--thread-cache-loading");
+    this.messages.render({
+      messages: shouldRenderMessages ? messages : [],
+      isLoading: false,
       shouldRenderMessages,
     });
   }

--- a/app/flowix-web/features/agent/thread-card/messages/agent-thread-card-messages-controller.ts
+++ b/app/flowix-web/features/agent/thread-card/messages/agent-thread-card-messages-controller.ts
@@ -1,4 +1,5 @@
 import type { AgentTypeKey } from "@/types/agent";
+import type { ChatMessage } from "@/types";
 import type { AppLanguage, I18nKey } from "@/lib/i18n";
 import type { ThreadState } from "@features/agent/store/chat-store";
 import {
@@ -27,6 +28,7 @@ export interface AgentThreadCardMessagesControllerOptions {
   getMessageCount: () => number;
   shouldLoadThreadMessages: () => boolean;
   renderThreadState: () => void;
+  renderResolvedSessionMessages: (messages: ChatMessage[]) => void;
   applyResolvedSession: (
     threadId: string,
     sessionId: string,
@@ -78,6 +80,7 @@ export class AgentThreadCardMessagesController {
       getMessageCount: options.getMessageCount,
       shouldLoad: options.shouldLoadThreadMessages,
       render: options.renderThreadState,
+      renderResolvedSessionMessages: options.renderResolvedSessionMessages,
       applyResolvedSession: options.applyResolvedSession,
     });
   }

--- a/app/flowix-web/features/agent/thread-card/messages/message-item-renderer.ts
+++ b/app/flowix-web/features/agent/thread-card/messages/message-item-renderer.ts
@@ -1,4 +1,4 @@
-import type { AppLanguage } from "@/lib/i18n";
+import { translate, type AppLanguage } from "@/lib/i18n";
 import type { ThreadState } from "@features/agent/store/chat-store";
 import {
   createAgentMessageViewModel,
@@ -69,6 +69,7 @@ export function renderAgentThreadCardBudgetedMarkdown(options: {
   fillWithAgentThreadCardMarkdownHtml(
     content,
     renderAgentThreadCardMarkdownToHtml(display.text),
+    translate(context.language, "editor.threadCard.copyLatex"),
   );
 
   let toggle = directChildDisplayToggle(toggleParent);

--- a/app/flowix-web/features/agent/thread-card/messages/thread-cache-controller.test.ts
+++ b/app/flowix-web/features/agent/thread-card/messages/thread-cache-controller.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "@/types";
+import { loadAgentThreadCardCache } from "@features/agent/thread-card/agent-thread-card-cache";
+import { ThreadCacheController } from "@features/agent/thread-card/messages/thread-cache-controller";
+
+vi.mock("@features/agent/thread-card/agent-thread-card-cache", () => ({
+  loadAgentThreadCardCache: vi.fn(async () => ({
+    resolvedSessionId: null,
+    loadedThreadId: "thread-1",
+    messages: [],
+  })),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ThreadCacheController", () => {
+  it("schedules visible history loading while idle", async () => {
+    let idleCallback: IdleRequestCallback | undefined;
+    const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+      idleCallback = callback;
+      return 1;
+    });
+    vi.stubGlobal("requestIdleCallback", requestIdleCallback);
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+
+    const render = vi.fn();
+    const controller = new ThreadCacheController({
+      element: document.createElement("div"),
+      isDestroyed: () => false,
+      getThreadId: () => "thread-1",
+      getTypeKey: () => "codex",
+      getMessageCount: () => 0,
+      shouldLoad: () => true,
+      render,
+      renderResolvedSessionMessages: vi.fn(),
+      applyResolvedSession: vi.fn(),
+    });
+
+    controller.requestIfNeeded();
+    expect(loadAgentThreadCardCache).not.toHaveBeenCalled();
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+
+    idleCallback?.({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    });
+
+    await vi.waitFor(() =>
+      expect(loadAgentThreadCardCache).toHaveBeenCalledTimes(1),
+    );
+    expect(loadAgentThreadCardCache).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      typeKey: "codex",
+    });
+
+    await vi.waitFor(() => expect(controller.isLoading).toBe(false));
+    expect(controller.isLoading).toBe(false);
+    expect(render).toHaveBeenCalled();
+
+    controller.dispose();
+  });
+
+  it("renders resolved session messages before replacing the local id", async () => {
+    let idleCallback: IdleRequestCallback | undefined;
+    vi.stubGlobal(
+      "requestIdleCallback",
+      vi.fn((callback: IdleRequestCallback) => {
+        idleCallback = callback;
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelIdleCallback", vi.fn());
+    const pendingLoad: {
+      resolve?: (value: {
+        resolvedSessionId: string;
+        loadedThreadId: string;
+        messages: ChatMessage[];
+      }) => void;
+    } = {};
+    vi.mocked(loadAgentThreadCardCache).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          pendingLoad.resolve = resolve;
+        }),
+    );
+
+    const messages = [{ id: "message-1" }] as ChatMessage[];
+    const callOrder: string[] = [];
+    const renderResolvedSessionMessages = vi.fn(() => {
+      callOrder.push("render");
+    });
+    const applyResolvedSession = vi.fn(() => {
+      callOrder.push("apply");
+    });
+    const controller = new ThreadCacheController({
+      element: document.createElement("div"),
+      isDestroyed: () => false,
+      getThreadId: () => "thread-1",
+      getTypeKey: () => "codex",
+      getMessageCount: () => 0,
+      shouldLoad: () => true,
+      render: vi.fn(),
+      renderResolvedSessionMessages,
+      applyResolvedSession,
+    });
+
+    controller.requestIfNeeded();
+    idleCallback?.({
+      didTimeout: false,
+      timeRemaining: () => 50,
+    });
+    await vi.waitFor(() =>
+      expect(loadAgentThreadCardCache).toHaveBeenCalledTimes(1),
+    );
+    pendingLoad.resolve?.({
+      resolvedSessionId: "session-1",
+      loadedThreadId: "session-1",
+      messages,
+    });
+
+    await vi.waitFor(() =>
+      expect(applyResolvedSession).toHaveBeenCalledWith(
+        "thread-1",
+        "session-1",
+        "codex",
+      ),
+    );
+    expect(renderResolvedSessionMessages).toHaveBeenCalledWith(messages);
+    expect(callOrder).toEqual(["render", "apply"]);
+
+    controller.dispose();
+  });
+});

--- a/app/flowix-web/features/agent/thread-card/messages/thread-cache-controller.ts
+++ b/app/flowix-web/features/agent/thread-card/messages/thread-cache-controller.ts
@@ -1,4 +1,5 @@
 import type { AgentTypeKey } from "@/types/agent";
+import type { ChatMessage } from "@/types";
 import { loadAgentThreadCardCache } from "@features/agent/thread-card/agent-thread-card-cache";
 
 export interface ThreadCacheControllerOptions {
@@ -9,6 +10,7 @@ export interface ThreadCacheControllerOptions {
   getMessageCount: () => number;
   shouldLoad: () => boolean;
   render: () => void;
+  renderResolvedSessionMessages: (messages: ChatMessage[]) => void;
   applyResolvedSession: (
     threadId: string,
     sessionId: string,
@@ -24,6 +26,9 @@ export class ThreadCacheController {
   private readonly getMessageCount: () => number;
   private readonly shouldLoad: () => boolean;
   private readonly render: () => void;
+  private readonly renderResolvedSessionMessages: (
+    messages: ChatMessage[],
+  ) => void;
   private readonly applyResolvedSession: (
     threadId: string,
     sessionId: string,
@@ -49,6 +54,7 @@ export class ThreadCacheController {
     this.getMessageCount = options.getMessageCount;
     this.shouldLoad = options.shouldLoad;
     this.render = options.render;
+    this.renderResolvedSessionMessages = options.renderResolvedSessionMessages;
     this.applyResolvedSession = options.applyResolvedSession;
   }
 
@@ -126,6 +132,7 @@ export class ThreadCacheController {
           const typeKey = this.getTypeKey();
           const result = await loadAgentThreadCardCache({ threadId, typeKey });
           if (result.resolvedSessionId) {
+            this.renderResolvedSessionMessages(result.messages);
             this.applyResolvedSession(threadId, result.resolvedSessionId, typeKey);
             return;
           }

--- a/app/flowix-web/lib/i18n/messages.en-US.ts
+++ b/app/flowix-web/lib/i18n/messages.en-US.ts
@@ -1000,6 +1000,7 @@ const enUS: Record<keyof typeof zhCN, string> = {
     "editor.threadCard.expand": "Expand",
     "editor.threadCard.collapse": "Collapse",
     "editor.threadCard.copySessionId": "Copy Session ID",
+    "editor.threadCard.copyLatex": "Copy LaTeX",
     "editor.threadCard.model": "Model",
     "editor.threadCard.lastRun": "Last run",
     "editor.threadCard.totalTokens": "Total tokens",

--- a/app/flowix-web/lib/i18n/messages.zh-CN.ts
+++ b/app/flowix-web/lib/i18n/messages.zh-CN.ts
@@ -970,6 +970,7 @@ const zhCN = {
     "editor.threadCard.expand": "展开",
     "editor.threadCard.collapse": "收起",
     "editor.threadCard.copySessionId": "复制 Session ID",
+    "editor.threadCard.copyLatex": "复制 LaTeX",
     "editor.threadCard.model": "模型",
     "editor.threadCard.lastRun": "上次运行",
     "editor.threadCard.totalTokens": "Tokens",

--- a/app/flowix-web/styles/agent-thread-card/markdown.css
+++ b/app/flowix-web/styles/agent-thread-card/markdown.css
@@ -203,6 +203,88 @@
  *  - <pre><code>foo</code></pre>          不命中 (pre 是 pre)
  * 编辑器正文也不带背景色 ── 仅靠 1px 边框 + 字色 80% 透明弱化做区分。
  * 卡片跨三处 (Tiptap 正文 / 卡片 / 右栏面板) 走同一套 token。 */
+.markdown-editor .agent-thread-card__message-content .agent-thread-card__math,
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math
+  * {
+  cursor: copy;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math--inline {
+  display: inline;
+  max-width: 100%;
+  border-radius: 4px;
+  padding: 0 2px;
+  vertical-align: baseline;
+  white-space: nowrap;
+  transition: background-color 120ms ease;
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math--block {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 8px 0;
+  padding: 0 10px;
+  overflow: visible;
+  border: 1px solid color-mix(in oklch, var(--border) 82%, transparent);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--muted) 58%, transparent);
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+/* Keep display math naturally sized while allowing long formulas to scroll. */
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math-scroller {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 12px 0;
+  box-sizing: border-box;
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math:hover {
+  background: color-mix(in oklch, var(--primary) 10%, transparent);
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math:focus-visible {
+  outline: 2px solid color-mix(in oklch, var(--primary) 65%, transparent);
+  outline-offset: 2px;
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math--copied {
+  background: color-mix(in oklch, var(--primary) 16%, transparent);
+}
+
+.markdown-editor
+  .agent-thread-card__message-content
+  .agent-thread-card__math--block.agent-thread-card__math--copied {
+  border-color: color-mix(in oklch, var(--primary) 35%, var(--border));
+}
+
+.markdown-editor .agent-thread-card__message-content .katex-display {
+  margin: 0;
+}
+
 .markdown-editor .agent-thread-card__message-content :not(pre) > code {
   padding: 0 0.3rem;
   border: 1px solid color-mix(in oklch, var(--border) 90%, transparent);
@@ -563,5 +645,4 @@
   .agent-thread-card__loading-indicator {
   display: none;
 }
-
 


### PR DESCRIPTION
Related to #30 
Parse Codex inline and display math delimiters with Marked and render formulas using lazy-loaded KaTeX.

Preserve the original LaTeX for mouse and keyboard copying, localize the copy label, and add coverage for parsing, rendering, and streaming updates.

## What

Thread Card assistant messages now recognize `\(...\)`, `\[...\]`, and `$$...$$` through custom Marked extensions and render them with lazily loaded KaTeX.

Display formulas remain horizontally scrollable, while the original LaTeX is preserved for mouse and keyboard copying. Copy actions also include localized labels and keyboard support.

## Why

Codex responses frequently contain LaTeX delimiters that were previously displayed as raw text. This made formulas difficult to read and copy, especially for subscripts, superscripts, matrices, and multi-line display equations.

Parsing math through Marked keeps formulas compatible with Markdown code spans, code blocks, links, and incomplete streamed content.

## How tested

- [x] `npm test -- app/flowix-web/features/agent/thread-card/agent-thread-card-markdown.test.ts --testTimeout=30000`
- [x] `npm test -- app/flowix-web/features/agent/thread-card/agent-thread-card.test.ts app/flowix-web/features/agent/thread-card/messages --testTimeout=30000`
- [x] `npm test -- --testTimeout=30000 --maxWorkers=4`
- [x] `npm run build`
- [ ] `cargo test --workspace`
  - No Rust files were changed by this PR.
- [ ] `cargo fmt --check`
  - No Rust files were changed by this PR.
- [ ] `cargo clippy --workspace -- -D warnings`
  - Attempted, but it is blocked by existing `flowix-core` warnings.
  - No Rust files were changed by this PR.
- [x] Manual verification on Windows
  - Inline and display formulas render in Thread Cards.
  - Subscripts and superscripts use the expected KaTeX layout.
  - Display formulas remain contained and horizontally scrollable.
  - Formula content can be copied as the original LaTeX.

The unrestricted full test run produced one environment-sensitive timeout while dynamically importing the existing Thread Card module under high worker concurrency. The same test passed independently, and the complete 509-test suite passed with `--maxWorkers=4`.

## Risks

KaTeX and its stylesheet are loaded asynchronously when formulas first appear. If loading fails, the original LaTeX remains visible.

Incomplete delimiters remain plain text while a response is streaming and are rendered after the closing delimiter arrives.

Single-dollar delimiters such as `$value$` are intentionally unsupported to avoid interpreting currency and ordinary text as formulas.

Clipboard access may be unavailable or denied in some browser environments. Formula rendering remains functional in that case.

## Checklist

- [x] No secrets / tokens / `.env` files touched
- [x] No force-push to `main`
- [x] No public interface change requiring CHANGELOG or documentation updates
- [x] No schema change

## example
<img width="2211" height="1365" alt="屏幕截图 2026-07-28 225748" src="https://github.com/user-attachments/assets/9ab4e176-edd0-4f5e-a1e8-19afb861e640" />
