### PR TITLE
Make the status-bar Todos button toggle back to All

### DIFF
--- a/app/flowix-web/features/shell/main-layout.tsx
+++ b/app/flowix-web/features/shell/main-layout.tsx
@@ -565,15 +565,16 @@ export function MainLayout() {
   }, []);
 
   const handleOpenTodos = useCallback(async () => {
+    const nextFilter = activeFilter === 'todos' ? 'all' : 'todos';
     closePluginSurface();
     setMemoListVisible(true);
-    setActiveFilter('todos');
+    setActiveFilter(nextFilter);
     await loadMemos({
       notebookId: selectedNotebook?.id,
-      filter: 'todos',
+      filter: nextFilter,
       sort: activeSort,
     });
-  }, [activeSort, closePluginSurface, loadMemos, selectedNotebook?.id, setActiveFilter, setMemoListVisible]);
+  }, [activeFilter, activeSort, closePluginSurface, loadMemos, selectedNotebook?.id, setActiveFilter, setMemoListVisible]);
 
   // 状态栏 Agents 星标: 打开中间列展示 AgentConversationList,
   // 已在 agents 视图则 no-op, 不再回退。


### PR DESCRIPTION
Clicking Todos in the bottom status bar sets the memo list filter to todos, but there's no way back from that entry point. The only way to return to All is the separate filter dropdown at the top of the memo list, which is a few clicks away and isn't obvious from the status bar itself.

handleOpenTodos in main-layout.tsx now toggles: clicking again while already on todos switches the filter back to all, using the same setActiveFilter/loadMemos flow it already had.

Fixes half of #27 — the titlebar button height part of that issue was already fixed in v1.0.8, this covers the remaining toggle request.

No test file covers main-layout.tsx yet and the component pulls in a lot of Zustand store wiring, so I checked this by hand: tsc --noEmit is clean, and vitest run shows the same failing/passing counts with and without the change (some pre-existing localStorage mock failures unrelated to this file).